### PR TITLE
feat(actions): add generate-changelog action

### DIFF
--- a/actions/generate_changelog.go
+++ b/actions/generate_changelog.go
@@ -1,0 +1,143 @@
+package actions
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+	"text/template"
+
+	"github.com/codegangsta/cli"
+	"github.com/google/go-github/github"
+)
+
+const changelogTpl string = `{{.OldRelease}} -> {{.NewRelease}}
+
+# Features
+
+{{range .Features}} - {{.}}
+{{else}}No new features for this release.
+{{end}}
+
+# Fixes
+
+{{range .Fixes}} - {{.}}
+{{else}}No bug fixes for this release.
+{{end}}
+
+# Documentation
+
+{{range .Documentation}} - {{.}}
+{{else}}No new documentation for this release.
+{{end}}
+
+# Maintenance
+
+{{range .Maintenance}} - {{.}}
+{{else}}No maintenance required for this release.
+{{end}}`
+
+var changelogTemplate *template.Template = template.Must(template.New("changelog").Parse(changelogTpl))
+
+type Changelog struct {
+	OldRelease string
+	NewRelease string
+	Features []string
+	Fixes []string
+	Documentation []string
+	Maintenance []string
+}
+
+// GenerateChangelog is the CLI action for creating an aggregated changelog from all of the Deis Workflow repos.
+func GenerateChangelog(client *github.Client, dest io.Writer) func(*cli.Context) {
+	return func(c *cli.Context) {
+		changelog := &Changelog{
+			OldRelease: c.Args().Get(0),
+			NewRelease: c.Args().Get(1),
+		}
+		if changelog.OldRelease == "" || changelog.NewRelease == "" {
+			log.Fatal("Usage: generate-changelog <old-release> <new-release>")
+		}
+		if err := generateChangelog(client, changelog); err != nil {
+			log.Fatalf("could not generate changelog: %s", err)
+		}
+		err := changelogTemplate.Execute(dest, changelog)
+		if err != nil {
+			log.Fatalf("could not template changelog: %s", err)
+		}
+	}
+}
+
+func generateChangelog(client *github.Client, changelog *Changelog) error {
+	var wg sync.WaitGroup
+	done := make(chan bool)
+	errCh := make(chan error)
+	defer close(errCh)
+	for _, name := range repoNames {
+		wg.Add(1)
+		go func(name string) {
+			defer wg.Done()
+			commitCompare, resp, err := client.Repositories.CompareCommits("deis", name, changelog.OldRelease, changelog.NewRelease)
+			if err != nil {
+				if resp.StatusCode == http.StatusNotFound {
+					log.Printf("tag does not exist for this repo; skipping %s", name)
+					return
+				}
+				errCh <- fmt.Errorf("could not compare commits %s and %s: %s", changelog.OldRelease, changelog.NewRelease, err)
+			}
+			for _, commit := range commitCompare.Commits {
+				commitMessage := strings.Split(*commit.Commit.Message, "\n")[0]
+				changelogMessage := fmt.Sprintf("%s %s: %s", shortShaTransform(*commit.SHA), commitFocus(*commit.Commit.Message), commitTitle(*commit.Commit.Message))
+				if strings.HasPrefix(commitMessage, "feat(") {
+					changelog.Features = append(changelog.Features, changelogMessage)
+				} else if strings.HasPrefix(commitMessage, "fix(") {
+					changelog.Fixes = append(changelog.Fixes, changelogMessage)
+				} else if strings.HasPrefix(commitMessage, "docs(") {
+					changelog.Documentation = append(changelog.Documentation, changelogMessage)
+				} else if strings.HasPrefix(commitMessage, "chore(") {
+					changelog.Maintenance = append(changelog.Maintenance, changelogMessage)
+				} else {
+					log.Printf("skipping commit %s from %s", *commit.SHA, name)
+				}
+			}
+		}(name)
+	}
+	go func() {
+		// wait for all fetches from github to be complete before returning
+		wg.Wait()
+		close(done)
+	}()
+
+	for {
+		select {
+		case <-done:
+			return nil
+		case err := <-errCh:
+			return fmt.Errorf("could not generate changelog: %s", err)
+		}
+	}
+}
+
+func commitFocus(str string) string {
+	// first, some sanitization
+	// parse only the title, strip the commit body
+	str = strings.Split(str, "\n")[0]
+	if !strings.Contains(str, "(") || !strings.Contains(str, ")") {
+		return ""
+	}
+	// fetch the string between the parentheses
+	return strings.TrimSpace(strings.Split(strings.Split(str, ")")[0], "(")[1])
+}
+
+func commitTitle(str string) string {
+	// first, some sanitization
+	// parse only the title, strip the commit body
+	str = strings.Split(str, "\n")[0]
+	// if the commit title doesn't follow our standards, just dump the whole string
+	if !strings.Contains(str, ":") {
+		return str
+	}
+	return strings.TrimSpace(strings.Split(str, ":")[1])
+}

--- a/actions/generate_changelog_test.go
+++ b/actions/generate_changelog_test.go
@@ -1,0 +1,183 @@
+package actions
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/google/go-github/github"
+)
+
+type TestServer struct {
+	Server *httptest.Server
+	Client *github.Client
+	Mux *http.ServeMux
+}
+
+// NewTestServer sets up a test HTTP server along with a github.Client that is
+// configured to talk to that test server.  Tests should register handlers on
+// Mux which provide mock responses for the API method being tested.
+func NewTestServer() *TestServer {
+	// test server
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+
+	// github client configured to use test server
+	client := github.NewClient(nil)
+	url, _ := url.Parse(server.URL)
+	client.BaseURL = url
+	client.UploadURL = url
+
+	return &TestServer{
+		Server: server,
+		Client: client,
+		Mux: mux,
+	}
+}
+
+// Close closes the test HTTP server.
+func (t *TestServer) Close() {
+	t.Server.Close()
+}
+
+func TestGenerateChangelog(t *testing.T) {
+	ts := NewTestServer()
+	defer ts.Close()
+
+	ts.Mux.HandleFunc("/repos/deis/controller/compare/b...h", func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Method; got != "GET" {
+			t.Errorf("Request method: %v, want GET", got)
+		}
+		fmt.Fprintf(w, `{
+		  "base_commit": {
+		    "sha": "s",
+		    "commit": {
+		      "author": { "name": "n" },
+		      "committer": { "name": "n" },
+		      "message": "m",
+		      "tree": { "sha": "t" }
+		    },
+		    "author": { "login": "n" },
+		    "committer": { "login": "l" },
+		    "parents": [ { "sha": "s" } ]
+		  },
+		  "status": "s",
+		  "ahead_by": 1,
+		  "behind_by": 2,
+		  "total_commits": 1,
+		  "commits": [
+		    {
+		      "sha": "abc1234567890",
+		      "commit": { "author": { "name": "n" }, "message": "feat(deisrel): new feature!" },
+		      "author": { "login": "l" },
+		      "committer": { "login": "l" },
+		      "parents": [ { "sha": "s" } ]
+		    },
+		    {
+		      "sha": "abc2345678901",
+		      "commit": { "author": { "name": "n" }, "message": "fix(deisrel): bugfix!" },
+		      "author": { "login": "l" },
+		      "committer": { "login": "l" },
+		      "parents": [ { "sha": "s" } ]
+		    },
+		    {
+		      "sha": "abc3456789012",
+		      "commit": { "author": { "name": "n" }, "message": "docs(deisrel): new docs!" },
+		      "author": { "login": "l" },
+		      "committer": { "login": "l" },
+		      "parents": [ { "sha": "s" } ]
+		    },
+		    {
+		      "sha": "abc4567890123",
+		      "commit": { "author": { "name": "n" }, "message": "chore(deisrel): boring chore" },
+		      "author": { "login": "l" },
+		      "committer": { "login": "l" },
+		      "parents": [ { "sha": "s" } ]
+		    }
+		  ],
+		  "files": [ { "filename": "f" } ]
+		}`)
+	})
+
+	got := &Changelog{
+		OldRelease: "b",
+		NewRelease: "h",
+	}
+
+	if err := generateChangelog(ts.Client, got); err != nil {
+		t.Errorf("generateChangelog returned an error: %s", err)
+	}
+
+	want := &Changelog{
+		OldRelease: "b",
+		NewRelease: "h",
+		Features: []string{"abc1234 deisrel: new feature!"},
+		Fixes: []string{"abc2345 deisrel: bugfix!"},
+		Documentation: []string{"abc3456 deisrel: new docs!"},
+		Maintenance: []string{"abc4567 deisrel: boring chore"},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("generateChangelog returned \n%+v, want \n%+v", got, want)
+	}
+}
+
+func TestGenerateChangelog_NoRelevantCommits(t *testing.T) {
+	ts := NewTestServer()
+	defer ts.Close()
+
+	ts.Mux.HandleFunc("/repos/deis/r/compare/b...h", func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Method; got != "GET" {
+			t.Errorf("Request method: %v, want GET", got)
+		}
+		fmt.Fprintf(w, `{
+		  "base_commit": {
+		    "sha": "s",
+		    "commit": {
+		      "author": { "name": "n" },
+		      "committer": { "name": "n" },
+		      "message": "m",
+		      "tree": { "sha": "t" }
+		    },
+		    "author": { "login": "n" },
+		    "committer": { "login": "l" },
+		    "parents": [ { "sha": "s" } ]
+		  },
+		  "status": "s",
+		  "ahead_by": 1,
+		  "behind_by": 2,
+		  "total_commits": 1,
+		  "commits": [
+		    {
+		      "sha": "s",
+		      "commit": { "author": { "name": "n" } },
+		      "author": { "login": "l" },
+		      "committer": { "login": "l" },
+		      "parents": [ { "sha": "s" } ]
+		    }
+		  ],
+		  "files": [ { "filename": "f" } ]
+		}`)
+	})
+
+	got := &Changelog{
+		OldRelease: "b",
+		NewRelease: "h",
+	}
+
+	if err := generateChangelog(ts.Client, got); err != nil {
+		t.Errorf("generateChangelog returned an error: %s", err)
+	}
+
+	want := &Changelog{
+		OldRelease: "b",
+		NewRelease: "h",
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("generateChangelog returned \n%+v, want \n%+v", got, want)
+	}
+}

--- a/actions/generate_changelogs.go
+++ b/actions/generate_changelogs.go
@@ -1,1 +1,0 @@
-package actions

--- a/glide.lock
+++ b/glide.lock
@@ -1,16 +1,36 @@
-hash: 1217f6e580ab2b289d4cfd83313f1469d8b8e60ec3b7fe3808630d18739dabe6
-updated: 2016-04-14T15:42:39.034803362-07:00
+hash: a3bf6a4abc90d31415892ff8484e76893bd2c188f944a0d5b4aa563391398593
+updated: 2016-05-05T14:38:20.90346103-07:00
 imports:
 - name: github.com/codegangsta/cli
-  version: 71f57d300dd6a780ac1856c005c4b518cfd498ec
+  version: 75b97d09d9f5792ff997e249a330a3ca28f8b537
+- name: github.com/golang/protobuf
+  version: 7cc19b78d562895b13596ddce7aafb59dd789318
+  subpackages:
+  - proto
 - name: github.com/google/go-github
-  version: f8cebc8ad645ff0e5df4ffc1059f644c3cb99b1c
+  version: 842c551fdeae14c97c04ef490f601ae4d849a00c
   subpackages:
   - github
 - name: github.com/google/go-querystring
   version: 9235644dd9e52eeae6fa48efd539fdc351a0af53
   subpackages:
   - query
+- name: golang.org/x/net
+  version: 35ec611a141ee705590b9eb64d673f9e6dfeb1ac
+  subpackages:
+  - context
 - name: golang.org/x/oauth2
-  version: b0e2337fe6ec0c637fa4f123268b972f334504eb
+  version: e86e2718db89775a4604abc10a5d3a5672e7336e
+  subpackages:
+  - internal
+- name: google.golang.org/appengine
+  version: e234e71924d4aa52444bc76f2f831f13fa1eca60
+  subpackages:
+  - urlfetch
+  - internal
+  - internal/urlfetch
+  - internal/base
+  - internal/datastore
+  - internal/log
+  - internal/remote_api
 devImports: []

--- a/main.go
+++ b/main.go
@@ -39,6 +39,10 @@ func main() {
 			},
 		},
 		cli.Command{
+			Name: "generate-changelog",
+			Action: actions.GenerateChangelog(ghClient, os.Stdout),
+		},
+		cli.Command{
 			Name: "helm-params",
 			Flags: []cli.Flag{
 				cli.StringFlag{


### PR DESCRIPTION
given a FROM and a TO release, this command will generate an aggregated changelog of all that has
changed from one release to another.

Usage: `deisrel generate-changelog v2.0.0-beta2 v2.0.0-beta3`

To ignore all of the warnings add `2>/dev/null` at the end.

closes #2