### PR TITLE
feat(actions): add doc( tag for generating changelogs

### DIFF
--- a/actions/generate_changelog.go
+++ b/actions/generate_changelog.go
@@ -94,7 +94,7 @@ func generateChangelog(client *github.Client, changelog *Changelog) error {
 					changelog.Features = append(changelog.Features, changelogMessage)
 				} else if strings.HasPrefix(commitMessage, "fix(") {
 					changelog.Fixes = append(changelog.Fixes, changelogMessage)
-				} else if strings.HasPrefix(commitMessage, "docs(") {
+				} else if strings.HasPrefix(commitMessage, "docs(") || strings.HasPrefix(commitMessage, "doc(") {
 					changelog.Documentation = append(changelog.Documentation, changelogMessage)
 				} else if strings.HasPrefix(commitMessage, "chore(") {
 					changelog.Maintenance = append(changelog.Maintenance, changelogMessage)

--- a/actions/generate_changelog_test.go
+++ b/actions/generate_changelog_test.go
@@ -58,6 +58,13 @@ func TestGenerateChangelog(t *testing.T) {
 		    },
 		    {
 		      "sha": "abc4567890123",
+		      "commit": { "author": { "name": "n" }, "message": "doc(deisrel): new docs!" },
+		      "author": { "login": "l" },
+		      "committer": { "login": "l" },
+		      "parents": [ { "sha": "s" } ]
+		    },
+		    {
+		      "sha": "abc5678901234",
 		      "commit": { "author": { "name": "n" }, "message": "chore(deisrel): boring chore" },
 		      "author": { "login": "l" },
 		      "committer": { "login": "l" },
@@ -82,8 +89,8 @@ func TestGenerateChangelog(t *testing.T) {
 		NewRelease:    "h",
 		Features:      []string{"abc1234 deisrel: new feature!"},
 		Fixes:         []string{"abc2345 deisrel: bugfix!"},
-		Documentation: []string{"abc3456 deisrel: new docs!"},
-		Maintenance:   []string{"abc4567 deisrel: boring chore"},
+		Documentation: []string{"abc3456 deisrel: new docs!", "abc4567 deisrel: new docs!"},
+		Maintenance:   []string{"abc5678 deisrel: boring chore"},
 	}
 
 	if !reflect.DeepEqual(got, want) {


### PR DESCRIPTION
Sometimes contributors tag it with just `doc(` instead of `docs(`.

ping @krancour as he was requesting this feature