### PR TITLE
feat(actions): add deisrel git tag command

### DIFF
--- a/actions/common.go
+++ b/actions/common.go
@@ -6,10 +6,18 @@ import (
 	"path/filepath"
 )
 
-type releaseName struct {
-	Full  string
-	Short string
-}
+const (
+	// TagFlag represents the '-tag' flag
+	TagFlag = "tag"
+	// PullPolicyFlag represents the '-pull-policy' flag
+	PullPolicyFlag = "pull-policy"
+	// OrgFlag represents the '-org' flag
+	OrgFlag = "org"
+	// ShaFileFlag represents the --sha-filepath flag
+	ShaFilepathFlag = "sha-filepath"
+	// YesFlag represents the --yes flag
+	YesFlag = "yes"
+)
 
 var (
 	// TODO: https://github.com/deis/deisrel/issues/12
@@ -39,6 +47,11 @@ var (
 	}
 	stagingPath = getFullPath("staging")
 )
+
+type releaseName struct {
+	Full  string
+	Short string
+}
 
 func getRepoNames(repoToComponentNames map[string][]string) []string {
 	repoNames := make([]string, 0, len(repoToComponentNames))

--- a/actions/generate_changelog.go
+++ b/actions/generate_changelog.go
@@ -42,12 +42,12 @@ const changelogTpl string = `{{.OldRelease}} -> {{.NewRelease}}
 var changelogTemplate *template.Template = template.Must(template.New("changelog").Parse(changelogTpl))
 
 type Changelog struct {
-	OldRelease string
-	NewRelease string
-	Features []string
-	Fixes []string
+	OldRelease    string
+	NewRelease    string
+	Features      []string
+	Fixes         []string
 	Documentation []string
-	Maintenance []string
+	Maintenance   []string
 }
 
 // GenerateChangelog is the CLI action for creating an aggregated changelog from all of the Deis Workflow repos.

--- a/actions/git_test.go
+++ b/actions/git_test.go
@@ -1,0 +1,127 @@
+package actions
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/deis/deisrel/testutil"
+	"github.com/google/go-github/github"
+)
+
+// TestCreateGitTag tests that creating a tag should be ok
+func TestCreateGitTag(t *testing.T) {
+	ts := testutil.NewTestServer()
+	defer ts.Close()
+
+	ts.Mux.HandleFunc("/repos/deis/controller/git/refs", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" && r.Method != "GET" {
+			t.Errorf("Request method: %v, want GET or POST", r.Method)
+		}
+		tag := `
+		{
+		  "ref": "refs/heads/b",
+		  "url": "https://api.github.com/repos/deis/controller/git/refs/heads/b",
+		  "object": {
+		    "type": "commit",
+		    "sha": "aa218f56b14c9653891f9e74264a383fa43fefbd",
+		    "url": "https://api.github.com/repos/deis/controller/git/commits/aa218f56b14c9653891f9e74264a383fa43fefbd"
+		  }
+		}`
+		if r.Method == "GET" {
+			// return a list of tags
+			fmt.Fprintf(w, "[%s]", tag)
+		} else {
+			fmt.Fprint(w, tag)
+		}
+	})
+
+	repos := []repoAndSha{
+		{
+			repoName: "controller",
+			sha:      "aa218f56b14c9653891f9e74264a383fa43fefbd",
+		},
+	}
+
+	if err := createGitTag(ts.Client, repos, "b"); err != nil {
+		t.Errorf("createGitTag returned error: %v", err)
+	}
+
+	refs, _, err := ts.Client.Git.ListRefs("deis", "controller", nil)
+	if err != nil {
+		t.Errorf("Git.ListRefs returned error: %v", err)
+	}
+
+	want := []github.Reference{
+		{
+			Ref: github.String("refs/heads/b"),
+			URL: github.String("https://api.github.com/repos/deis/controller/git/refs/heads/b"),
+			Object: &github.GitObject{
+				Type: github.String("commit"),
+				SHA:  github.String("aa218f56b14c9653891f9e74264a383fa43fefbd"),
+				URL:  github.String("https://api.github.com/repos/deis/controller/git/commits/aa218f56b14c9653891f9e74264a383fa43fefbd"),
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(refs, want) {
+		t.Errorf("createGitTag returned %+v, want %+v", refs, want)
+	}
+}
+
+// TestCreateGitTagAlreadyExists tests that creating a tag that already exists should be fine
+func TestCreateGitTagAlreadyExists(t *testing.T) {
+	ts := testutil.NewTestServer()
+	defer ts.Close()
+
+	ts.Mux.HandleFunc("/repos/deis/controller/git/refs", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("Request method: %v, want POST", r.Method)
+		}
+		w.WriteHeader(github.StatusUnprocessableEntity)
+		fmt.Fprintf(w, `{
+		  "message": "Reference already exists",
+		  "documentation_url": "https://developer.github.com/v3/git/refs/#create-a-reference"
+		}`)
+	})
+
+	repos := []repoAndSha{
+		{
+			repoName: "controller",
+			sha:      "aa218f56b14c9653891f9e74264a383fa43fefbd",
+		},
+	}
+
+	if err := createGitTag(ts.Client, repos, "b"); err != nil {
+		t.Errorf("createGitTag returned error: %v", err)
+	}
+}
+
+// TestCreateGitTagBadSHA tests that creating a tag with a bad SHA should fail
+func TestCreateGitTagBadSHA(t *testing.T) {
+	ts := testutil.NewTestServer()
+	defer ts.Close()
+
+	ts.Mux.HandleFunc("/repos/deis/controller/git/refs", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("Request method: %v, want POST", r.Method)
+		}
+		w.WriteHeader(github.StatusUnprocessableEntity)
+		fmt.Fprintf(w, `{
+		  "message": "Object does not exist",
+		  "documentation_url": "https://developer.github.com/v3/git/refs/#create-a-reference"
+		}`)
+	})
+
+	repos := []repoAndSha{
+		{
+			repoName: "controller",
+			sha:      "aa218f56b14c9653891f9e74264a383fa43fefbd",
+		},
+	}
+
+	if err := createGitTag(ts.Client, repos, "b"); err == nil {
+		t.Error("createGitTag didn't return an error when the API says it's an invalid SHA")
+	}
+}

--- a/actions/helm_generate_e2e.go
+++ b/actions/helm_generate_e2e.go
@@ -8,15 +8,6 @@ import (
 	"github.com/google/go-github/github"
 )
 
-const (
-	// TagFlag represents the '-tag' flag
-	TagFlag = "tag"
-	// PullPolicyFlag represents the '-pull-policy' flag
-	PullPolicyFlag = "pull-policy"
-	// OrgFlag represents the '-org' flag
-	OrgFlag = "org"
-)
-
 // HelmGenerateE2E is the cli handler for generating a helm parameters file for deis-e2e
 func HelmGenerateE2E(ghClient *github.Client) func(*cli.Context) {
 	return func(c *cli.Context) {

--- a/main.go
+++ b/main.go
@@ -36,10 +36,25 @@ func main() {
 						},
 					},
 				},
+				cli.Command{
+					Name:   "tag",
+					Action: actions.GitTag(ghClient),
+					Flags: []cli.Flag{
+						cli.BoolFlag{
+							Name:  actions.YesFlag,
+							Usage: "If true, skip the prompt requesting permission",
+						},
+						cli.StringFlag{
+							Name:  actions.ShaFilepathFlag,
+							Value: "",
+							Usage: "the file path which to read in the shas to release",
+						},
+					},
+				},
 			},
 		},
 		cli.Command{
-			Name: "generate-changelog",
+			Name:   "generate-changelog",
 			Action: actions.GenerateChangelog(ghClient, os.Stdout),
 		},
 		cli.Command{


### PR DESCRIPTION
This automates tagging all of the components at their latest SHAs. This can be overridden by
providing a --sha-filepath flag with a path to a file that has the component names and their
respective SHAs, separated by an equals sign.

closes #3