### PR TITLE
feat(generate_params.go): add versionsApiURL to prod for release chart

### DIFF
--- a/actions/generate_params.go
+++ b/actions/generate_params.go
@@ -97,6 +97,7 @@ dockerTag = "{{.Registry.Tag}}"
 org = "{{.WorkflowManager.Org}}"
 pullPolicy = "{{.WorkflowManager.PullPolicy}}"
 dockerTag = "{{.WorkflowManager.Tag}}"
+versionsApiURL = "https://versions.deis.com"
 
 [logger]
 org = "{{.Logger.Org}}"


### PR DESCRIPTION
Relating to https://github.com/deis/workflow/pull/223, this should obviate the need to manually update chart w/ prod value...