### PR TITLE
feat(helm_stage_e2e.go): add 'tpl/workflow-e2e-pod.yaml' to list

### DIFF
--- a/actions/helm_stage_e2e.go
+++ b/actions/helm_stage_e2e.go
@@ -16,6 +16,7 @@ func HelmStageE2E(ghClient *github.Client) func(*cli.Context) error {
 		var fileNames = []string{
 			fmt.Sprintf("%s/README.md", chartDir),
 			fmt.Sprintf("%s/Chart.yaml", chartDir),
+			fmt.Sprintf("%s/tpl/workflow-e2e-pod.yaml", chartDir),
 		}
 
 		stagingDir := filepath.Join(stagingPath, chartDir)


### PR DESCRIPTION
(e2e's pod name also needs the 'dev' -> '$WORKFLOW_RELEASE_SHORT' adjustment for cutting a release chart)