### PR TITLE
fix(actions/generate_changelog.go): output the repo for each commit message

### DIFF
--- a/actions/generate_changelog.go
+++ b/actions/generate_changelog.go
@@ -90,7 +90,7 @@ func generateChangelog(client *github.Client, changelog *Changelog) error {
 			}
 			for _, commit := range commitCompare.Commits {
 				commitMessage := strings.Split(*commit.Commit.Message, "\n")[0]
-				changelogMessage := fmt.Sprintf("%s %s: %s", shortShaTransform(*commit.SHA), commitFocus(*commit.Commit.Message), commitTitle(*commit.Commit.Message))
+				changelogMessage := fmt.Sprintf("%s (%s) - %s: %s", shortShaTransform(*commit.SHA), name, commitFocus(*commit.Commit.Message), commitTitle(*commit.Commit.Message))
 				if strings.HasPrefix(commitMessage, "feat(") {
 					changelog.Features = append(changelog.Features, changelogMessage)
 				} else if strings.HasPrefix(commitMessage, "fix(") {

--- a/actions/generate_changelog_test.go
+++ b/actions/generate_changelog_test.go
@@ -87,10 +87,10 @@ func TestGenerateChangelog(t *testing.T) {
 	want := &Changelog{
 		OldRelease:    "b",
 		NewRelease:    "h",
-		Features:      []string{"abc1234 deisrel: new feature!"},
-		Fixes:         []string{"abc2345 deisrel: bugfix!"},
-		Documentation: []string{"abc3456 deisrel: new docs!", "abc4567 deisrel: new docs!"},
-		Maintenance:   []string{"abc5678 deisrel: boring chore"},
+		Features:      []string{"abc1234 (controller) - deisrel: new feature!"},
+		Fixes:         []string{"abc2345 (controller) - deisrel: bugfix!"},
+		Documentation: []string{"abc3456 (controller) - deisrel: new docs!", "abc4567 (controller) - deisrel: new docs!"},
+		Maintenance:   []string{"abc5678 (controller) - deisrel: boring chore"},
 	}
 
 	if !reflect.DeepEqual(got, want) {


### PR DESCRIPTION
Fixes #43 

Sample output (I already had `$GITHUB_ACCESS_TOKEN` in my env):

```console
ENG000656:deisrel aaronschlesinger$ ./deisrel generate-changelog v2.0.0-beta3 v2.0.0-beta4 2> /dev/null
v2.0.0-beta3 -> v2.0.0-beta4

# Features

 - adb9b43 (minio) - secret: use objectstorage secret for creds than minio user secret
 - d4dcc0d (router) - config: move from time_local to time_iso8601
 - dce56d5 (router) - config: add application name as part of the log information
 - 16f8968 (workflow) - monitoring: Add platform-monitoring docs
 - eec2126 (workflow-e2e) - git: curl app endpoint for "Powered by"
 - 30e7b2f (builder) - controller: Show the error message from controller instead of resposnse code
 - 55f4256 (controller) - deploy: support doing a larger number than 1 in, 1 out deployment
 - be4fc6e (controller) - coverage: use yaml file for codecov.io
 - 0591f87 (controller) - scheduler: add in better pod cleanup procedure in mock and add in deletionTimestamp handling
 - 8ab1f78 (controller) - scheduler: add 10 mins to deploy timeout if image pull is slow
 - 491a066 (controller) - scheduler: clean up stray pods when a release is deleted


# Fixes

 - 495f33e (router) - router: Handle comma delimited X-Forwarded-For values
 - 4ec7722 (dockerbuilder) - docker-push: handle the docker push errors
 - 93c2569 (workflow) - installing-workflow: fix getting started guide links
 - 70139bc (workflow-e2e) - cli: update deis CLI to the latest version
 - eacaf38 (builder) - git-push: handle the errors during git push
 - 8e9de01 (builder) - cleaner: remove the usage of watch api
 - 9cc7852 (builder) - gitreceive: ignore error if `git gc` fails
 - 3105911 (controller) - app: catch a higher level python-requests exception for verify application health
 - bb84471 (controller) - scheduler: check if the pods are ready in scale up operations before comparing to desired state
 - e383586 (controller) - app: response object was not accessible if app verification threw request exception
 - a6c0ea1 (controller) - healthcheck: URL is required but set_healthcheck did not account for that
 - bb09ceb (controller) - readinessprobe: contianer shouldn't be restarted if the database is unavailable
 - 7392eb3 (controller) - config: proc type names validation should allow alphanumeric
 - 5b3af45 (controller) - tests: add missing tests for /readiness endpoint
 - 70ea69d (controller) - deploy: account for readiness initial delay when determining if a pod is ready
 - fdc72ca (controller) - port: retry a fixed number of times to find the port
 - 3ff8f59 (controller) - README: Kubernetes 1.2 is a minimum requirement now
 - fd7cabc (controller) - scheduler: use CA cert to verify API SSL certficiate
 - dab4911 (controller) - builds: User should be able to do a deploy an app after a failed attempt


# Documentation

 - a80d6cb (slugrunner) - CHANGELOG.md: update for v2.0.0-beta3
 - ee37258 (slugrunner) - CHANGELOG.md: add entry for v2.0.0-beta4
 - 469a7b8 (registry) - CHANGELOG.md: update for v2.0.0-beta3
 - d697730 (registry) - CHANGELOG.md: add entry for v2.0.0-beta4
 - 7a99710 (postgres) - CHANGELOG.md: update for v2.0.0-beta3
 - 1283422 (postgres) - CHANGELOG.md: add entry for v2.0.0-beta4
 - 24d602f (logger) - CHANGELOG.md: update for v2.0.0-beta3
 - 1e75fef (logger) - CHANGELOG.md: update for v2.0.0-beta4
 - 1093841 (workflow-manager) - CHANGELOG.md: update for v2.0.0-beta3
 - 9045f23 (workflow-manager) - badge: added code-beat badge
 - 577bf5a (workflow-manager) - CHANGELOG.md: add entry for v2.0.0-beta4
 - 27dd7ee (fluentd) - CHANGELOG.md: update for v2.0.0-beta3
 - 1b441fb (fluentd) - CHANGELOG.md: update for v2.0.0-beta4
 - 5f09346 (minio) - CHANGELOG.md: update for v2.0.0-beta3
 - 26cc4e3 (minio) - CHANGELOG.md: add entry for v2.0.0-beta4
 - e713d66 (slugbuilder) - CHANGELOG.md: update for v2.0.0-beta3
 - 0642601 (slugbuilder) - CHANGELOG.md: add entry for v2.0.0-beta4
 - 9491c1c (router) - CHANGELOG.md: update for v2.0.0-beta3
 - 0ff01c3 (router) - README: Apply minor updates
 - f200b9c (router) - CHANGELOG.md: add entry for v2.0.0-beta4
 - a1c5304 (dockerbuilder) - CHANGELOG.md: update for v2.0.0-beta3
 - f15703d (dockerbuilder) - badge: added code-beat badge
 - f6836aa (dockerbuilder) - CHANGELOG.md: add entry for v2.0.0-beta4
 - 7392f68 (workflow) - release-checklist: note that milestones should be closed
 - c3c9d62 (workflow) - CHANGELOG.md: update for v2.0.0-beta3
 - 6938862 (workflow) - README.md: add slack signup & status badge
 - e9b0c7c (workflow) - release-checklist: add minor adjustments and reminder
 - 16ef691 (workflow) - release: add an extra step to point to versions.deis.com
 - a42d82d (workflow) - CHANGELOG.md: update for v2.0.0-beta4
 - 34628bd (workflow-e2e) - CHANGELOG.md: update for v2.0.0-beta3
 - ce5a2b9 (workflow-e2e) - CHANGELOG.md: add entry for v2.0.0-beta4
 - d64b400 (builder) - CHANGELOG.md: update for v2.0.0-beta3
 - d8fe502 (builder) - badge: added code-beat badge
 - 142b0b7 (builder) - CHANGELOG.md: add entry for beta4
 - 92a2a10 (controller) - CHANGELOG.md: update for v2.0.0-beta3
 - d087ab3 (controller) - helmc: update the docs to use helm classic instead of helm
 - 2412db6 (controller) - CHANGELOG.md: add entry for v2.0.0-beta4


# Maintenance

 - 29072ad (registry) - Makefile: update go-dev to 0.11.1
 - a4d5d69 (slugbuilder) - buildpacks: update heroku-buildpack-scala to v70
 - c9b526c (slugbuilder) - buildpacks: update heroku-buildpack-go to v34
 - 2e81ae6 (slugbuilder) - buildpacks: update heroku-buildpack-nodejs to v90
 - b0f2c69 (slugbuilder) - buildpacks: update heroku-buildpack-php to v102
 - 42d038c (workflow) - src: bump documentation to reference v2.0.0-beta3
 - fe7d82e (workflow) - release: add a new removal step for release-checklist
 - d271c2b (workflow-e2e) - logs: Add deis logs test
 - f4714c7 (workflow-e2e) - makefile: Add the ability to focus a test
 - 6441ece (builder) - Makefile: update go-dev to 0.11.1
 - 1def311 (controller) - settings: Allow for comma-delimited RESERVED_NAMES
 - 61726ec (controller) - requirements: update pytz to 2016.4
 - e4fc4db (controller) - requirements: update codecov lib to 2.0.3
 - 3e2c025 (controller) - requirements: Django 1.9.6
 - af5963c (controller) - requirements: update docker-py to 1.8.1
 - 122ace6 (controller) - versioneye: add version eye integration
 - aae80f4 (controller) - requirements: Update to python-requets 2.10.0
 - df10ebb (controller) - tests: improve coverage by triggering KubeExceptions (and other types)
 - 222ec0c (controller) - requirements: update requests-toolbelt to 0.6.1
 - f5f2917 (controller) - tests: output the content/data of the response when status code does not match
 - 938246b (controller) - tests: add long message to all assert functions that use status_code checks
```