### PR TITLE
feat(main.go,actions): add command to generate a changelog entry for an individual repo

### DIFF
--- a/actions/changelog_util.go
+++ b/actions/changelog_util.go
@@ -1,0 +1,27 @@
+package actions
+
+import (
+	"strings"
+)
+
+func commitFocus(str string) string {
+	// first, some sanitization
+	// parse only the title, strip the commit body
+	str = strings.Split(str, "\n")[0]
+	if !strings.Contains(str, "(") || !strings.Contains(str, ")") {
+		return ""
+	}
+	// fetch the string between the parentheses
+	return strings.TrimSpace(strings.Split(strings.Split(str, ")")[0], "(")[1])
+}
+
+func commitTitle(str string) string {
+	// first, some sanitization
+	// parse only the title, strip the commit body
+	str = strings.Split(str, "\n")[0]
+	// if the commit title doesn't follow our standards, just dump the whole string
+	if !strings.Contains(str, ":") {
+		return str
+	}
+	return strings.TrimSpace(strings.Split(str, ":")[1])
+}

--- a/actions/generate_changelog.go
+++ b/actions/generate_changelog.go
@@ -58,7 +58,7 @@ func GenerateChangelog(client *github.Client, dest io.Writer) func(*cli.Context)
 			NewRelease: c.Args().Get(1),
 		}
 		if changelog.OldRelease == "" || changelog.NewRelease == "" {
-			log.Fatal("Usage: generate-changelog <old-release> <new-release>")
+			log.Fatal("Usage: changelog global <old-release> <new-release>")
 		}
 		if err := generateChangelog(client, changelog); err != nil {
 			log.Fatalf("could not generate changelog: %s", err)
@@ -119,26 +119,4 @@ func generateChangelog(client *github.Client, changelog *Changelog) error {
 			return fmt.Errorf("could not generate changelog: %s", err)
 		}
 	}
-}
-
-func commitFocus(str string) string {
-	// first, some sanitization
-	// parse only the title, strip the commit body
-	str = strings.Split(str, "\n")[0]
-	if !strings.Contains(str, "(") || !strings.Contains(str, ")") {
-		return ""
-	}
-	// fetch the string between the parentheses
-	return strings.TrimSpace(strings.Split(strings.Split(str, ")")[0], "(")[1])
-}
-
-func commitTitle(str string) string {
-	// first, some sanitization
-	// parse only the title, strip the commit body
-	str = strings.Split(str, "\n")[0]
-	// if the commit title doesn't follow our standards, just dump the whole string
-	if !strings.Contains(str, ":") {
-		return str
-	}
-	return strings.TrimSpace(strings.Split(str, ":")[1])
 }

--- a/actions/generate_individual_changelog.go
+++ b/actions/generate_individual_changelog.go
@@ -1,0 +1,98 @@
+package actions
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"text/template"
+
+	"github.com/codegangsta/cli"
+	"github.com/google/go-github/github"
+)
+
+const individualChangelogTplStr string = `{{.OldRelease}} -> {{.NewRelease}}
+
+# Features
+
+{{range .Features}} - {{.}}
+{{else}}No new features for this release.
+{{end}}
+
+# Fixes
+
+{{range .Fixes}} - {{.}}
+{{else}}No bug fixes for this release.
+{{end}}
+
+# Documentation
+
+{{range .Documentation}} - {{.}}
+{{else}}No new documentation for this release.
+{{end}}
+
+# Maintenance
+
+{{range .Maintenance}} - {{.}}
+{{else}}No maintenance required for this release.
+{{end}}`
+
+var individualChangelogTpl *template.Template = template.Must(template.New("changelog").Parse(individualChangelogTplStr))
+
+type IndividualChangelog struct {
+	OldRelease    string
+	NewRelease    string
+	Features      []string
+	Fixes         []string
+	Documentation []string
+	Maintenance   []string
+}
+
+// GenerateIndividualChangelog is the CLI action for creating a changelog for a single repo
+func GenerateIndividualChangelog(client *github.Client, dest io.Writer) func(*cli.Context) error {
+	return func(c *cli.Context) error {
+		repoName := c.Args().Get(0)
+		changelog := &Changelog{
+			OldRelease: c.Args().Get(1),
+			NewRelease: c.Args().Get(2),
+		}
+		if changelog.OldRelease == "" || changelog.NewRelease == "" {
+			log.Fatal("Usage: changelog individual <repo> <old-release> <new-release>")
+		}
+		if err := generateIndividualChangelog(client, changelog, repoName); err != nil {
+			log.Fatalf("could not generate changelog: %s", err)
+		}
+		err := individualChangelogTpl.Execute(dest, changelog)
+		if err != nil {
+			log.Fatalf("could not template changelog: %s", err)
+		}
+		return nil
+	}
+}
+
+func generateIndividualChangelog(client *github.Client, changelog *Changelog, name string) error {
+	commitCompare, resp, err := client.Repositories.CompareCommits("deis", name, changelog.OldRelease, changelog.NewRelease)
+	if err != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			log.Printf("tag does not exist for this repo; skipping %s", name)
+		}
+		return fmt.Errorf("could not compare commits %s and %s: %s", changelog.OldRelease, changelog.NewRelease, err)
+	}
+	for _, commit := range commitCompare.Commits {
+		commitMessage := strings.Split(*commit.Commit.Message, "\n")[0]
+		changelogMessage := fmt.Sprintf("%s %s: %s", shortShaTransform(*commit.SHA), commitFocus(*commit.Commit.Message), commitTitle(*commit.Commit.Message))
+		if strings.HasPrefix(commitMessage, "feat(") {
+			changelog.Features = append(changelog.Features, changelogMessage)
+		} else if strings.HasPrefix(commitMessage, "fix(") {
+			changelog.Fixes = append(changelog.Fixes, changelogMessage)
+		} else if strings.HasPrefix(commitMessage, "docs(") || strings.HasPrefix(commitMessage, "doc(") {
+			changelog.Documentation = append(changelog.Documentation, changelogMessage)
+		} else if strings.HasPrefix(commitMessage, "chore(") {
+			changelog.Maintenance = append(changelog.Maintenance, changelogMessage)
+		} else {
+			log.Printf("skipping commit %s from %s", *commit.SHA, name)
+		}
+	}
+	return nil
+}

--- a/actions/generate_individual_changelog.go
+++ b/actions/generate_individual_changelog.go
@@ -20,7 +20,7 @@ func GenerateIndividualChangelog(client *github.Client, dest io.Writer) func(*cl
 			OldRelease: c.Args().Get(1),
 			NewRelease: c.Args().Get(3),
 		}
-		if vals.OldRelease == "" || vals.NewRelease == "" || sha == "" {
+		if vals.OldRelease == "" || vals.NewRelease == "" || sha == "" || repoName == "" {
 			log.Fatal("Usage: changelog individual <repo> <old-release> <sha> <new-release>")
 		}
 		skippedCommits, err := changelog.SingleRepoVals(client, vals, sha, repoName)

--- a/actions/generate_individual_changelog.go
+++ b/actions/generate_individual_changelog.go
@@ -4,97 +4,39 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"net/http"
-	"strings"
-	"text/template"
+	"os"
 
 	"github.com/codegangsta/cli"
+	"github.com/deis/deisrel/changelog"
 	"github.com/google/go-github/github"
 )
-
-const individualChangelogTplStr string = `{{.OldRelease}} -> {{.NewRelease}}
-
-# Features
-
-{{range .Features}} - {{.}}
-{{else}}No new features for this release.
-{{end}}
-
-# Fixes
-
-{{range .Fixes}} - {{.}}
-{{else}}No bug fixes for this release.
-{{end}}
-
-# Documentation
-
-{{range .Documentation}} - {{.}}
-{{else}}No new documentation for this release.
-{{end}}
-
-# Maintenance
-
-{{range .Maintenance}} - {{.}}
-{{else}}No maintenance required for this release.
-{{end}}`
-
-var individualChangelogTpl *template.Template = template.Must(template.New("changelog").Parse(individualChangelogTplStr))
-
-type IndividualChangelog struct {
-	OldRelease    string
-	NewRelease    string
-	Sha           string
-	Features      []string
-	Fixes         []string
-	Documentation []string
-	Maintenance   []string
-}
 
 // GenerateIndividualChangelog is the CLI action for creating a changelog for a single repo
 func GenerateIndividualChangelog(client *github.Client, dest io.Writer) func(*cli.Context) error {
 	return func(c *cli.Context) error {
 		repoName := c.Args().Get(0)
-		changelog := &IndividualChangelog{
+		sha := c.Args().Get(2)
+		vals := &changelog.Values{
 			OldRelease: c.Args().Get(1),
-			Sha:        c.Args().Get(2),
 			NewRelease: c.Args().Get(3),
 		}
-		if changelog.OldRelease == "" || changelog.NewRelease == "" || changelog.Sha == "" {
+		if vals.OldRelease == "" || vals.NewRelease == "" || sha == "" {
 			log.Fatal("Usage: changelog individual <repo> <old-release> <sha> <new-release>")
 		}
-		if err := generateIndividualChangelog(client, changelog, repoName); err != nil {
+		skippedCommits, err := changelog.SingleRepoVals(client, vals, sha, repoName)
+
+		if len(skippedCommits) > 0 {
+			for _, ci := range skippedCommits {
+				fmt.Fprintln(os.Stderr, "skipping commit", ci)
+			}
+		}
+
+		if err != nil {
 			log.Fatalf("could not generate changelog: %s", err)
 		}
-		err := individualChangelogTpl.Execute(dest, changelog)
-		if err != nil {
+		if err := changelog.Tpl.Execute(dest, vals); err != nil {
 			log.Fatalf("could not template changelog: %s", err)
 		}
 		return nil
 	}
-}
-
-func generateIndividualChangelog(client *github.Client, changelog *IndividualChangelog, name string) error {
-	commitCompare, resp, err := client.Repositories.CompareCommits("deis", name, changelog.OldRelease, changelog.Sha)
-	if err != nil {
-		if resp.StatusCode == http.StatusNotFound {
-			log.Printf("tag does not exist for this repo; skipping %s", name)
-		}
-		return fmt.Errorf("could not compare commits %s and %s: %s", changelog.OldRelease, changelog.NewRelease, err)
-	}
-	for _, commit := range commitCompare.Commits {
-		commitMessage := strings.Split(*commit.Commit.Message, "\n")[0]
-		changelogMessage := fmt.Sprintf("%s %s: %s", shortShaTransform(*commit.SHA), commitFocus(*commit.Commit.Message), commitTitle(*commit.Commit.Message))
-		if strings.HasPrefix(commitMessage, "feat(") {
-			changelog.Features = append(changelog.Features, changelogMessage)
-		} else if strings.HasPrefix(commitMessage, "fix(") {
-			changelog.Fixes = append(changelog.Fixes, changelogMessage)
-		} else if strings.HasPrefix(commitMessage, "docs(") || strings.HasPrefix(commitMessage, "doc(") {
-			changelog.Documentation = append(changelog.Documentation, changelogMessage)
-		} else if strings.HasPrefix(commitMessage, "chore(") {
-			changelog.Maintenance = append(changelog.Maintenance, changelogMessage)
-		} else {
-			log.Printf("skipping commit %s from %s", *commit.SHA, name)
-		}
-	}
-	return nil
 }

--- a/changelog/changelog.go
+++ b/changelog/changelog.go
@@ -1,0 +1,48 @@
+package changelog
+
+import (
+	"text/template"
+)
+
+const (
+	tplStr = `{{.OldRelease}} -> {{.NewRelease}}
+
+# Features
+
+{{range .Features}} - {{.}}
+{{else}}No new features for this release.
+{{end}}
+
+# Fixes
+
+{{range .Fixes}} - {{.}}
+{{else}}No bug fixes for this release.
+{{end}}
+
+# Documentation
+
+{{range .Documentation}} - {{.}}
+{{else}}No new documentation for this release.
+{{end}}
+
+# Maintenance
+
+{{range .Maintenance}} - {{.}}
+{{else}}No maintenance required for this release.
+{{end}}`
+)
+
+var (
+	// Tpl is the standard changelog template. Execute it with a Values struct
+	Tpl = template.Must(template.New("changelog").Parse(tplStr))
+)
+
+// Values represents the values that are required to render a changelog
+type Values struct {
+	OldRelease    string
+	NewRelease    string
+	Features      []string
+	Fixes         []string
+	Documentation []string
+	Maintenance   []string
+}

--- a/changelog/changelog.go
+++ b/changelog/changelog.go
@@ -10,28 +10,25 @@ const (
 {{ if (len .Features) gt 0 }}
 # Features
 
-{{range .Features}} - {{.}}
+{{range .Features}}- {{.}}
 {{end}}
-{{end}}
-
-{{ if (len .Fixes) gt 0 }}
+{{ end -}}
+{{ if (len .Fixes) gt 0 -}}
 # Fixes
 
-{{range .Fixes}} - {{.}}
+{{range .Fixes}}- {{.}}
 {{end}}
-{{end}}
-
+{{ end }}
 {{ if (len .Documentation) gt 0 }}
 # Documentation
 
-{{range .Documentation}} - {{.}}
+{{range .Documentation}}- {{.}}
 {{end}}
 {{end}}
-
 {{ if (len .Maintenance) gt 0 }}
 # Maintenance
 
-{{range .Maintenance}} - {{.}}
+{{range .Maintenance}}- {{.}}
 {{end}}
 {{end}}`
 )

--- a/changelog/changelog.go
+++ b/changelog/changelog.go
@@ -7,28 +7,32 @@ import (
 const (
 	tplStr = `{{.OldRelease}} -> {{.NewRelease}}
 
+{{ if (len .Features) gt 0 }}
 # Features
 
 {{range .Features}} - {{.}}
-{{else}}No new features for this release.
+{{end}}
 {{end}}
 
+{{ if (len .Fixes) gt 0 }}
 # Fixes
 
 {{range .Fixes}} - {{.}}
-{{else}}No bug fixes for this release.
+{{end}}
 {{end}}
 
+{{ if (len .Documentation) gt 0 }}
 # Documentation
 
 {{range .Documentation}} - {{.}}
-{{else}}No new documentation for this release.
+{{end}}
 {{end}}
 
+{{ if (len .Maintenance) gt 0 }}
 # Maintenance
 
 {{range .Maintenance}} - {{.}}
-{{else}}No maintenance required for this release.
+{{end}}
 {{end}}`
 )
 

--- a/changelog/changelog_test.go
+++ b/changelog/changelog_test.go
@@ -1,0 +1,97 @@
+package changelog
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+const (
+	oldRelease = "old"
+	newRelease = "new"
+)
+
+var (
+	features      = []string{"feature1"}
+	fixes         = []string{"fix1"}
+	documentation = []string{"doc1"}
+	maintenance   = []string{"maint1"}
+)
+
+func TestTemplate(t *testing.T) {
+	type testCase struct {
+		vals    Values
+		missing string
+	}
+	testCases := []testCase{
+		testCase{
+			vals: Values{
+				OldRelease:    oldRelease,
+				NewRelease:    newRelease,
+				Features:      features,
+				Fixes:         fixes,
+				Documentation: documentation,
+				Maintenance:   maintenance,
+			},
+			missing: "",
+		},
+		testCase{
+			vals: Values{
+				OldRelease:    oldRelease,
+				NewRelease:    newRelease,
+				Features:      nil,
+				Fixes:         fixes,
+				Documentation: documentation,
+				Maintenance:   maintenance,
+			},
+			missing: "# Features",
+		},
+		testCase{
+			vals: Values{
+				OldRelease:    oldRelease,
+				NewRelease:    newRelease,
+				Features:      features,
+				Fixes:         nil,
+				Documentation: documentation,
+				Maintenance:   maintenance,
+			},
+			missing: "# Fixes",
+		},
+		testCase{
+			vals: Values{
+				OldRelease:    oldRelease,
+				NewRelease:    newRelease,
+				Features:      features,
+				Fixes:         fixes,
+				Documentation: nil,
+				Maintenance:   maintenance,
+			},
+			missing: "# Documentation",
+		},
+		testCase{
+			vals: Values{
+				OldRelease:    oldRelease,
+				NewRelease:    newRelease,
+				Features:      features,
+				Fixes:         fixes,
+				Documentation: documentation,
+				Maintenance:   nil,
+			},
+			missing: "# Maintenance",
+		},
+	}
+
+	for i, testCase := range testCases {
+		var buf bytes.Buffer
+		if err := Tpl.Execute(&buf, testCase.vals); err != nil {
+			t.Errorf("Error executing template %d (%s)", i, err)
+			continue
+		}
+		if len(testCase.missing) > 0 {
+			outStr := string(buf.Bytes())
+			if strings.Contains(outStr, testCase.missing) {
+				t.Errorf("Expected [%s] to be missing from the rendered template %d, but found it", testCase.missing, i)
+			}
+		}
+	}
+}

--- a/changelog/single_repo.go
+++ b/changelog/single_repo.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-github/github"
 )
 
+// SingleRepoVals generates a changelog entry from vals.OldRelease to sha. It returns the commits that were unparseable (and had to be skipped) or any error encountered during the process. On a nil error, vals is filled in with all of the sorted changelog entries
 func SingleRepoVals(client *github.Client, vals *Values, sha, name string) ([]string, error) {
 	var skippedCommits []string
 	commitCompare, resp, err := client.Repositories.CompareCommits("deis", name, vals.OldRelease, sha)

--- a/changelog/single_repo.go
+++ b/changelog/single_repo.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/go-github/github"
 )
 
-// SingleRepoVals generates a changelog entry from vals.OldRelease to sha. It returns the commits that were unparseable (and had to be skipped) or any error encountered during the process. On a nil error, vals is filled in with all of the sorted changelog entries
+// SingleRepoVals generates a changelog entry from vals.OldRelease to sha. It returns the commits that were unparseable (and had to be skipped) or any error encountered during the process. On a nil error, vals is filled in with all of the sorted changelog entries. Note that any nil commits will not be in the returned string slice
 func SingleRepoVals(client *github.Client, vals *Values, sha, name string) ([]string, error) {
 	var skippedCommits []string
 	commitCompare, resp, err := client.Repositories.CompareCommits("deis", name, vals.OldRelease, sha)

--- a/changelog/single_repo.go
+++ b/changelog/single_repo.go
@@ -1,0 +1,42 @@
+package changelog
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/deis/deisrel/git"
+	"github.com/google/go-github/github"
+)
+
+func SingleRepoVals(client *github.Client, vals *Values, sha, name string) ([]string, error) {
+	var skippedCommits []string
+	commitCompare, resp, err := client.Repositories.CompareCommits("deis", name, vals.OldRelease, sha)
+	if err != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			return nil, errTagNotFoundForRepo{repoName: name, tagName: vals.OldRelease}
+		}
+		return nil, errCouldNotCompareCommits{old: vals.OldRelease, new: sha, err: err}
+	}
+	for _, commit := range commitCompare.Commits {
+		commitMessage := strings.Split(*commit.Commit.Message, "\n")[0]
+		changelogMessage := fmt.Sprintf(
+			"%s %s: %s",
+			git.ShortSHATransform(*commit.SHA),
+			commitFocus(*commit.Commit.Message),
+			commitTitle(*commit.Commit.Message),
+		)
+		if strings.HasPrefix(commitMessage, "feat(") {
+			vals.Features = append(vals.Features, changelogMessage)
+		} else if strings.HasPrefix(commitMessage, "fix(") {
+			vals.Fixes = append(vals.Fixes, changelogMessage)
+		} else if strings.HasPrefix(commitMessage, "docs(") || strings.HasPrefix(commitMessage, "doc(") {
+			vals.Documentation = append(vals.Documentation, changelogMessage)
+		} else if strings.HasPrefix(commitMessage, "chore(") {
+			vals.Maintenance = append(vals.Maintenance, changelogMessage)
+		} else {
+			skippedCommits = append(skippedCommits, *commit.SHA)
+		}
+	}
+	return skippedCommits, nil
+}

--- a/changelog/single_repo_err.go
+++ b/changelog/single_repo_err.go
@@ -1,0 +1,24 @@
+package changelog
+
+import (
+	"fmt"
+)
+
+type errTagNotFoundForRepo struct {
+	repoName string
+	tagName  string
+}
+
+func (e errTagNotFoundForRepo) Error() string {
+	return fmt.Sprintf("tag %s not found for repo %s", e.tagName, e.repoName)
+}
+
+type errCouldNotCompareCommits struct {
+	old string
+	new string
+	err error
+}
+
+func (e errCouldNotCompareCommits) Error() string {
+	return fmt.Sprintf("could not compare commits %s - %s (%s)", e.old, e.new, e.err)
+}

--- a/changelog/single_repo_test.go
+++ b/changelog/single_repo_test.go
@@ -1,0 +1,156 @@
+package changelog
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/deis/deisrel/testutil"
+)
+
+func TestGenerateChangelog(t *testing.T) {
+	ts := testutil.NewTestServer()
+	defer ts.Close()
+
+	ts.Mux.HandleFunc("/repos/deis/controller/compare/b...h", func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Method; got != "GET" {
+			t.Errorf("Request method: %v, want GET", got)
+		}
+		fmt.Fprintf(w, `{
+		  "base_commit": {
+		    "sha": "s",
+		    "commit": {
+		      "author": { "name": "n" },
+		      "committer": { "name": "n" },
+		      "message": "m",
+		      "tree": { "sha": "t" }
+		    },
+		    "author": { "login": "n" },
+		    "committer": { "login": "l" },
+		    "parents": [ { "sha": "s" } ]
+		  },
+		  "status": "s",
+		  "ahead_by": 1,
+		  "behind_by": 2,
+		  "total_commits": 1,
+		  "commits": [
+		    {
+		      "sha": "abc1234567890",
+		      "commit": { "author": { "name": "n" }, "message": "feat(deisrel): new feature!" },
+		      "author": { "login": "l" },
+		      "committer": { "login": "l" },
+		      "parents": [ { "sha": "s" } ]
+		    },
+		    {
+		      "sha": "abc2345678901",
+		      "commit": { "author": { "name": "n" }, "message": "fix(deisrel): bugfix!" },
+		      "author": { "login": "l" },
+		      "committer": { "login": "l" },
+		      "parents": [ { "sha": "s" } ]
+		    },
+		    {
+		      "sha": "abc3456789012",
+		      "commit": { "author": { "name": "n" }, "message": "docs(deisrel): new docs!" },
+		      "author": { "login": "l" },
+		      "committer": { "login": "l" },
+		      "parents": [ { "sha": "s" } ]
+		    },
+		    {
+		      "sha": "abc4567890123",
+		      "commit": { "author": { "name": "n" }, "message": "doc(deisrel): new docs!" },
+		      "author": { "login": "l" },
+		      "committer": { "login": "l" },
+		      "parents": [ { "sha": "s" } ]
+		    },
+		    {
+		      "sha": "abc5678901234",
+		      "commit": { "author": { "name": "n" }, "message": "chore(deisrel): boring chore" },
+		      "author": { "login": "l" },
+		      "committer": { "login": "l" },
+		      "parents": [ { "sha": "s" } ]
+		    }
+		  ],
+		  "files": [ { "filename": "f" } ]
+		}`)
+	})
+
+	got := &Changelog{
+		OldRelease: "b",
+		NewRelease: "h",
+	}
+
+	if err := SingleRepoVals(ts.Client, got); err != nil {
+		t.Errorf("generateChangelog returned an error: %s", err)
+	}
+
+	want := &Values{
+		OldRelease:    "b",
+		NewRelease:    "h",
+		Features:      []string{"abc1234 deisrel: new feature!"},
+		Fixes:         []string{"abc2345 deisrel: bugfix!"},
+		Documentation: []string{"abc3456 deisrel: new docs!", "abc4567 deisrel: new docs!"},
+		Maintenance:   []string{"abc5678 deisrel: boring chore"},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("generateChangelog returned \n%+v, want \n%+v", got, want)
+	}
+}
+
+func TestGenerateChangelog_NoRelevantCommits(t *testing.T) {
+	ts := testutil.NewTestServer()
+	defer ts.Close()
+
+	ts.Mux.HandleFunc("/repos/deis/r/compare/b...h", func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Method; got != "GET" {
+			t.Errorf("Request method: %v, want GET", got)
+		}
+		fmt.Fprintf(w, `{
+		  "base_commit": {
+		    "sha": "s",
+		    "commit": {
+		      "author": { "name": "n" },
+		      "committer": { "name": "n" },
+		      "message": "m",
+		      "tree": { "sha": "t" }
+		    },
+		    "author": { "login": "n" },
+		    "committer": { "login": "l" },
+		    "parents": [ { "sha": "s" } ]
+		  },
+		  "status": "s",
+		  "ahead_by": 1,
+		  "behind_by": 2,
+		  "total_commits": 1,
+		  "commits": [
+		    {
+		      "sha": "s",
+		      "commit": { "author": { "name": "n" } },
+		      "author": { "login": "l" },
+		      "committer": { "login": "l" },
+		      "parents": [ { "sha": "s" } ]
+		    }
+		  ],
+		  "files": [ { "filename": "f" } ]
+		}`)
+	})
+
+	got := &Changelog{
+		OldRelease: "b",
+		NewRelease: "h",
+	}
+
+	if err := generateChangelog(ts.Client, got); err != nil {
+		t.Errorf("generateChangelog returned an error: %s", err)
+	}
+
+	want := &Changelog{
+		OldRelease: "b",
+		NewRelease: "h",
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("generateChangelog returned \n%+v, want \n%+v", got, want)
+	}
+}

--- a/changelog/single_repo_test.go
+++ b/changelog/single_repo_test.go
@@ -3,9 +3,9 @@ package changelog
 import (
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
 
+	"github.com/arschles/assert"
 	"github.com/deis/deisrel/testutil"
 )
 
@@ -75,14 +75,14 @@ func TestGenerateChangelog(t *testing.T) {
 		}`)
 	})
 
-	got := &Changelog{
+	got := &Values{
 		OldRelease: "b",
 		NewRelease: "h",
 	}
 
-	if err := SingleRepoVals(ts.Client, got); err != nil {
-		t.Errorf("generateChangelog returned an error: %s", err)
-	}
+	skipped, err := SingleRepoVals(ts.Client, got, "sha", "repo")
+	assert.NoErr(t, err)
+	assert.Equal(t, len(skipped), 0, "number of skipped commits")
 
 	want := &Values{
 		OldRelease:    "b",
@@ -93,12 +93,10 @@ func TestGenerateChangelog(t *testing.T) {
 		Maintenance:   []string{"abc5678 deisrel: boring chore"},
 	}
 
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("generateChangelog returned \n%+v, want \n%+v", got, want)
-	}
+	assert.Equal(t, got, want, "returned changelog values")
 }
 
-func TestGenerateChangelog_NoRelevantCommits(t *testing.T) {
+func TestGenerateChangelogWithNoRelevantCommits(t *testing.T) {
 	ts := testutil.NewTestServer()
 	defer ts.Close()
 
@@ -136,21 +134,19 @@ func TestGenerateChangelog_NoRelevantCommits(t *testing.T) {
 		}`)
 	})
 
-	got := &Changelog{
+	got := &Values{
 		OldRelease: "b",
 		NewRelease: "h",
 	}
 
-	if err := generateChangelog(ts.Client, got); err != nil {
-		t.Errorf("generateChangelog returned an error: %s", err)
-	}
+	skipped, err := SingleRepoVals(ts.Client, got, "sha", "repo")
+	assert.NoErr(t, err)
+	assert.Equal(t, len(skipped), 0, "number of skipped commits")
 
-	want := &Changelog{
+	want := &Values{
 		OldRelease: "b",
 		NewRelease: "h",
 	}
 
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("generateChangelog returned \n%+v, want \n%+v", got, want)
-	}
+	assert.Equal(t, got, want, "returned values struct")
 }

--- a/changelog/single_repo_test.go
+++ b/changelog/single_repo_test.go
@@ -100,7 +100,7 @@ func TestGenerateChangelogWithNoRelevantCommits(t *testing.T) {
 	ts := testutil.NewTestServer()
 	defer ts.Close()
 
-	ts.Mux.HandleFunc("/repos/deis/r/compare/b...h", func(w http.ResponseWriter, r *http.Request) {
+	ts.Mux.HandleFunc("/repos/deis/controller/compare/b...h", func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Method; got != "GET" {
 			t.Errorf("Request method: %v, want GET", got)
 		}
@@ -139,7 +139,7 @@ func TestGenerateChangelogWithNoRelevantCommits(t *testing.T) {
 		NewRelease: "h",
 	}
 
-	skipped, err := SingleRepoVals(ts.Client, got, "sha", "repo")
+	skipped, err := SingleRepoVals(ts.Client, got, "h", "controller")
 	assert.NoErr(t, err)
 	assert.Equal(t, len(skipped), 0, "number of skipped commits")
 

--- a/changelog/single_repo_test.go
+++ b/changelog/single_repo_test.go
@@ -80,7 +80,7 @@ func TestGenerateChangelog(t *testing.T) {
 		NewRelease: "h",
 	}
 
-	skipped, err := SingleRepoVals(ts.Client, got, "sha", "repo")
+	skipped, err := SingleRepoVals(ts.Client, got, "h", "controller")
 	assert.NoErr(t, err)
 	assert.Equal(t, len(skipped), 0, "number of skipped commits")
 

--- a/changelog/util.go
+++ b/changelog/util.go
@@ -1,0 +1,27 @@
+package changelog
+
+import (
+	"strings"
+)
+
+func commitFocus(str string) string {
+	// first, some sanitization
+	// parse only the title, strip the commit body
+	str = strings.Split(str, "\n")[0]
+	if !strings.Contains(str, "(") || !strings.Contains(str, ")") {
+		return ""
+	}
+	// fetch the string between the parentheses
+	return strings.TrimSpace(strings.Split(strings.Split(str, ")")[0], "(")[1])
+}
+
+func commitTitle(str string) string {
+	// first, some sanitization
+	// parse only the title, strip the commit body
+	str = strings.Split(str, "\n")[0]
+	// if the commit title doesn't follow our standards, just dump the whole string
+	if !strings.Contains(str, ":") {
+		return str
+	}
+	return strings.TrimSpace(strings.Split(str, ":")[1])
+}

--- a/changelog/util.go
+++ b/changelog/util.go
@@ -23,5 +23,5 @@ func commitTitle(str string) string {
 	if !strings.Contains(str, ":") {
 		return str
 	}
-	return strings.TrimSpace(strings.Split(str, ":")[1])
+	return strings.TrimSpace(strings.Join(strings.Split(str, ":")[1:], ":"))
 }

--- a/changelog/util.go
+++ b/changelog/util.go
@@ -9,7 +9,7 @@ func commitFocus(str string) string {
 	// parse only the title, strip the commit body
 	str = strings.Split(str, "\n")[0]
 	if !strings.Contains(str, "(") || !strings.Contains(str, ")") {
-		return ""
+		return "*" // return a asterisk so that commits with no focus are marked with a focus of "all"
 	}
 	// fetch the string between the parentheses
 	return strings.TrimSpace(strings.Split(strings.Split(str, ")")[0], "(")[1])

--- a/changelog/util_test.go
+++ b/changelog/util_test.go
@@ -1,0 +1,23 @@
+package changelog
+
+import (
+	"testing"
+
+	"github.com/arschles/assert"
+)
+
+func TestCommitFocus(t *testing.T) {
+	// find a valid focus
+	assert.Equal(t, commitFocus("fix(builder): some stuff"), "builder", "focus")
+	// find a missing focus
+	assert.Equal(t, commitFocus("fix: some stuff"), "*", "focus")
+}
+
+func TestCommitTitle(t *testing.T) {
+	// find a valid title
+	assert.Equal(t, commitTitle("fix(builder): some stuff"), "some stuff", "title")
+	// ensure the whole thing is dumped when there's no parseable title
+	assert.Equal(t, commitTitle("fix(builder) some stuff"), "fix(builder) some stuff", "title")
+	// ensure everything after the first ':' is returned
+	assert.Equal(t, commitTitle("fix(builder): stuff1: stuff2"), "stuff1: stuff2", "title")
+}

--- a/git/sha.go
+++ b/git/sha.go
@@ -1,7 +1,21 @@
 package git
 
+import (
+	"errors"
+)
+
+var (
+	// ErrSHANotLongEnough is the error returned from various functions in this package when a given SHA is not long enough for use
+	ErrSHANotLongEnough = errors.New("SHA not long enough")
+)
+
 // NoTransform returns a git sha without any transformation on it. This function exists as a pair with ShortShaTransform. It is simply the identity function
 func NoTransform(s string) string { return s }
 
-// ShortSHATransform returns the shortened version of the given SHA given in s
-func ShortSHATransform(s string) string { return s[:7] }
+// ShortSHATransform returns the shortened version of the given SHA given in s. If the given string is not long enough, returns the empty string and ErrSHANotLongEnough
+func ShortSHATransform(s string) (string, error) {
+	if len(s) < 7 {
+		return "", ErrSHANotLongEnough
+	}
+	return s[:7], nil
+}

--- a/git/sha.go
+++ b/git/sha.go
@@ -1,0 +1,7 @@
+package git
+
+// NoTransform returns a git sha without any transformation on it. This function exists as a pair with ShortShaTransform. It is simply the identity function
+func NoTransform(s string) string { return s }
+
+// ShortSHATransform returns the shortened version of the given SHA given in s
+func ShortSHATransform(s string) string { return s[:7] }

--- a/main.go
+++ b/main.go
@@ -61,8 +61,21 @@ func main() {
 			},
 		},
 		cli.Command{
-			Name:   "generate-changelog",
-			Action: actions.GenerateChangelog(ghClient, os.Stdout),
+			Name: "changelog",
+			Subcommands: []cli.Command{
+				cli.Command{
+					Name:        "global",
+					Action:      actions.GenerateChangelog(ghClient, os.Stdout),
+					Usage:       "deisrel changelog global <old-release> <new-release>",
+					Description: "Aggregate changelog entries from all known repositories for a specified release",
+				},
+				cli.Command{
+					Name:        "individual",
+					Action:      actions.GenerateIndividualChangelog(ghClient, os.Stdout),
+					Usage:       "deisrel changelog individual <repo-name> <old-release> <new-release>",
+					Description: "Generate a changelog entry for an changes on an individual repository for a specified release",
+				},
+			},
 		},
 		cli.Command{
 			Name: "helm-params",

--- a/main.go
+++ b/main.go
@@ -72,8 +72,8 @@ func main() {
 				cli.Command{
 					Name:        "individual",
 					Action:      actions.GenerateIndividualChangelog(ghClient, os.Stdout),
-					Usage:       "deisrel changelog individual <repo-name> <old-release> <new-release>",
-					Description: "Generate a changelog entry for an changes on an individual repository for a specified release",
+					Usage:       "deisrel changelog individual <repo-name> <old-release> <sha> <new-release>",
+					Description: "Generate a changelog entry for an changes on an individual repository, from a specified old release through a specified git SHA. The release will be called the specified new release in the changelog's title",
 				},
 			},
 		},


### PR DESCRIPTION
Fixes #45 

TODO:

- [ ] ~~documentation changes in `deis/workflow`~~ (captured in https://github.com/deis/workflow/issues/230)

Sample output:

```console
ENG000656:deisrel aaronschlesinger$ GITHUB_TOKEN=$GITHUB_ACCESS_TOKEN ./deisrel changelog individual builder v2.0.0-beta3 8215d19 v2.0.0-beta4 2> /dev/null
v2.0.0-beta3 -> v2.0.0-beta4

# Features

 - 30e7b2f controller: Show the error message from controller instead of resposnse code


# Fixes

 - eacaf38 git-push: handle the errors during git push
 - 8e9de01 cleaner: remove the usage of watch api
 - 9cc7852 gitreceive: ignore error if `git gc` fails


# Documentation

 - d64b400 CHANGELOG.md: update for v2.0.0-beta3
 - d8fe502 badge: added code-beat badge
 - 142b0b7 CHANGELOG.md: add entry for beta4


# Maintenance

 - 6441ece Makefile: update go-dev to 0.11.1
```