### PR TITLE
feat(getShas): add ability to pass in ref to git shas cmd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ else
 endif
 
 REPO_PATH := github.com/deis/${SHORT_NAME}
-DEV_ENV_IMAGE := quay.io/deis/go-dev:0.9.1
+DEV_ENV_IMAGE := quay.io/deis/go-dev:0.13.0
 DEV_ENV_WORK_DIR := /go/src/${REPO_PATH}
 DEV_ENV_PREFIX := docker run --rm -e GO15VENDOREXPERIMENT=1 -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR}
 DEV_ENV_CMD := ${DEV_ENV_PREFIX} ${DEV_ENV_IMAGE}

--- a/actions/get_shas.go
+++ b/actions/get_shas.go
@@ -20,7 +20,7 @@ func GetShas(ghClient *github.Client) func(c *cli.Context) error {
 		if c.Bool(ShortFlag) {
 			transformFunc = shortShaTransform
 		}
-		reposAndShas, err := getShas(ghClient, repoNames, transformFunc)
+		reposAndShas, err := getShas(ghClient, repoNames, transformFunc, c.GlobalString(RefFlag))
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/actions/git.go
+++ b/actions/git.go
@@ -21,7 +21,7 @@ type repoAndSha struct {
 func noTransform(s string) string       { return s }
 func shortShaTransform(s string) string { return s[:7] }
 
-func getShas(ghClient *github.Client, repos []string, transform func(string) string) ([]repoAndSha, error) {
+func getShas(ghClient *github.Client, repos []string, transform func(string) string, ref string) ([]repoAndSha, error) {
 	outCh := make(chan repoAndSha)
 	errCh := make(chan error)
 	doneCh := make(chan struct{})
@@ -32,6 +32,7 @@ func getShas(ghClient *github.Client, repos []string, transform func(string) str
 		ech := make(chan error)
 		go func(repo string) {
 			repoCommits, _, err := ghClient.Repositories.ListCommits("deis", repo, &github.CommitsListOptions{
+				SHA: ref,
 				ListOptions: github.ListOptions{
 					Page:    1,
 					PerPage: 1,
@@ -104,7 +105,7 @@ func GitTag(client *github.Client) func(c *cli.Context) error {
 			log.Fatal("Usage: deisrel git tag <options> <tag>")
 		}
 
-		repos, err := getShas(client, repoNames, noTransform)
+		repos, err := getShas(client, repoNames, noTransform, c.GlobalString(RefFlag))
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/actions/helm_generate.go
+++ b/actions/helm_generate.go
@@ -39,7 +39,7 @@ func executeToStaging(fs fileSys, stagingSubDir string) (io.WriteCloser, error) 
 	return fs.Create(filepath.Join(stagingSubDir, generateParamsFileName))
 }
 
-func getParamsComponentMap(ghClient *github.Client, defaultParamsComponentAttrs genParamsComponentAttrs, template *template.Template) genParamsComponentMap {
+func getParamsComponentMap(ghClient *github.Client, defaultParamsComponentAttrs genParamsComponentAttrs, template *template.Template, ref string) genParamsComponentMap {
 	paramsComponentMap := createParamsComponentMap()
 
 	if template == generateParamsE2ETpl {
@@ -52,7 +52,7 @@ func getParamsComponentMap(ghClient *github.Client, defaultParamsComponentAttrs 
 
 	if defaultParamsComponentAttrs.Tag == "" {
 		// gather latest sha for each repo via GitHub api
-		reposAndShas, err := getShas(ghClient, repoNames, shortShaTransform)
+		reposAndShas, err := getShas(ghClient, repoNames, shortShaTransform, ref)
 		if err != nil {
 			log.Fatalf("No tag given and couldn't fetch sha from GitHub (%s)", err)
 		} else if len(reposAndShas) < 1 {

--- a/actions/helm_stage.go
+++ b/actions/helm_stage.go
@@ -52,7 +52,7 @@ func helmStage(ghClient *github.Client, c *cli.Context, helmChart helmChart) {
 		PullPolicy: c.GlobalString(PullPolicyFlag),
 		Tag:        c.GlobalString(TagFlag),
 	}
-	paramsComponentMap := getParamsComponentMap(ghClient, defaultParamsComponentAttrs, helmChart.Template)
+	paramsComponentMap := getParamsComponentMap(ghClient, defaultParamsComponentAttrs, helmChart.Template, c.GlobalString(RefFlag))
 	generateParams(ourFS, stagingDir, paramsComponentMap, helmChart)
 }
 

--- a/actions/helm_stage_test.go
+++ b/actions/helm_stage_test.go
@@ -40,7 +40,7 @@ func TestDownloadFiles(t *testing.T) {
 		    "url": "",
 		    "git_url": "",
 		    "html_url": "",
-		    "download_url": "https://raw.githubusercontent.com/` + org + `/` + repo + `master/` + filePath + `",
+		    "download_url": "https://raw.githubusercontent.com/` + org + `/` + repo + `/master/` + filePath + `",
 		    "_links": {
 		      "self": "",
 		      "git": "",

--- a/main.go
+++ b/main.go
@@ -41,6 +41,11 @@ func main() {
 							Name:  actions.ShortFlag,
 							Usage: "Whether to show short 7 character shas",
 						},
+						cli.StringFlag{
+							Name:  actions.RefFlag,
+							Value: "master",
+							Usage: "Optional ref to add to GitHub repo request (can be SHA, branch or tag)",
+						},
 					},
 				},
 				cli.Command{
@@ -102,8 +107,8 @@ func main() {
 				},
 				cli.StringFlag{
 					Name:  actions.RefFlag,
-					Value: "",
-					Usage: "Optional ref to add to GET request (can be SHA, branch or tag); will be omitted if empty",
+					Value: "master",
+					Usage: "Optional ref to add to GitHub repo request (can be SHA, branch or tag)",
 				},
 				cli.StringFlag{
 					Name:  actions.GHOrgFlag,


### PR DESCRIPTION
So that the commit shas returned from a given repo can be from a
specific ref (SHA or branch) as opposed to default of master...

# Associated [Documentation](https://github.com/deis/workflow) PR(s)

If your change requires any additions or changes to the [Release Checklist](https://github.com/deis/workflow/blob/master/src/roadmap/release-checklist.md), please submit them as 1 or more pull requests against that repo and refer to them here.

Ref deis/workflow#1234
Ref deis/workflow#5678
