### PR TITLE
fix(actions/common.go): remove 'workflow' from repo/component list...

### DIFF
--- a/actions/common.go
+++ b/actions/common.go
@@ -59,7 +59,6 @@ var (
 		"slugbuilder":      {"SlugBuilder"},
 		"slugrunner":       {"SlugRunner"},
 		"stdout-metrics":   {"StdoutMetrics"},
-		"workflow":         {"Workflow"},
 		"workflow-e2e":     {"WorkflowE2E"},
 		"workflow-manager": {"WorkflowManager"},
 	}


### PR DESCRIPTION

...as workflow is not a repo/component that deisrel is concerned with
(meaning, does not have a value needing updating for a release chart
or a corresponding Docker image needing tag updates)