### PR TITLE
fix(get_shas.go): ref wasn't getting to get shas method

### DIFF
--- a/actions/get_shas.go
+++ b/actions/get_shas.go
@@ -20,7 +20,7 @@ func GetShas(ghClient *github.Client) func(c *cli.Context) error {
 		if c.Bool(ShortFlag) {
 			transformFunc = shortShaTransform
 		}
-		reposAndShas, err := getShas(ghClient, repoNames, transformFunc, c.GlobalString(RefFlag))
+		reposAndShas, err := getShas(ghClient, repoNames, transformFunc, c.String(RefFlag))
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/actions/git.go
+++ b/actions/git.go
@@ -31,13 +31,14 @@ func getShas(ghClient *github.Client, repos []string, transform func(string) str
 		ch := make(chan repoAndSha)
 		ech := make(chan error)
 		go func(repo string) {
-			repoCommits, _, err := ghClient.Repositories.ListCommits("deis", repo, &github.CommitsListOptions{
+			commitsListOpts := &github.CommitsListOptions{
 				SHA: ref,
 				ListOptions: github.ListOptions{
 					Page:    1,
 					PerPage: 1,
 				},
-			})
+			}
+			repoCommits, _, err := ghClient.Repositories.ListCommits("deis", repo, commitsListOpts)
 			if err != nil {
 				ech <- fmt.Errorf("Error listing commits for repo %s (%s)", repo, err)
 				return
@@ -105,7 +106,7 @@ func GitTag(client *github.Client) func(c *cli.Context) error {
 			log.Fatal("Usage: deisrel git tag <options> <tag>")
 		}
 
-		repos, err := getShas(client, repoNames, noTransform, c.GlobalString(RefFlag))
+		repos, err := getShas(client, repoNames, noTransform, c.String(RefFlag))
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/main.go
+++ b/main.go
@@ -61,6 +61,11 @@ func main() {
 							Value: "",
 							Usage: "the file path which to read in the shas to release",
 						},
+						cli.StringFlag{
+							Name:  actions.RefFlag,
+							Value: "master",
+							Usage: "Optional ref to add to GitHub repo request (can be SHA, branch or tag)",
+						},
 					},
 				},
 			},


### PR DESCRIPTION
`./deisrel git tag` didn't previously allow the use of a `--ref <branch or sha>` flag.  This change enables passing the flag