### PR TITLE
chore(actions/release_walker.go): update version string change

### DIFF
--- a/actions/helm_stage_test.go
+++ b/actions/helm_stage_test.go
@@ -162,7 +162,7 @@ func TestUpdateFilesWithRelease(t *testing.T) {
 
 	fileName := "foo/bar"
 	fakeFS.Create(fileName)
-	fakeFS.WriteFile(fileName, []byte("name: workflow-dev, version: v2-beta"), os.ModePerm)
+	fakeFS.WriteFile(fileName, []byte("name: workflow-dev, version: v2.0.0"), os.ModePerm)
 	var deisRelease = releaseName{
 		Full:  "foobar",
 		Short: "bar",
@@ -184,7 +184,7 @@ func TestUpdateFilesWithReleaseWithoutRelease(t *testing.T) {
 
 	fileName := "foo/bar"
 	fakeFS.Create(fileName)
-	fakeFS.WriteFile(fileName, []byte("name: workflow-dev, version: v2-beta"), os.ModePerm)
+	fakeFS.WriteFile(fileName, []byte("name: workflow-dev, version: v2.0.0"), os.ModePerm)
 	fakeFP.WalkInvoked = false
 
 	err := updateFilesWithRelease(fakeFP, fakeFS, deisRelease, fileName)
@@ -195,6 +195,6 @@ func TestUpdateFilesWithReleaseWithoutRelease(t *testing.T) {
 	assert.NoErr(t, err)
 	assert.Equal(t,
 		actualFileContents,
-		[]byte("name: workflow-dev, version: v2-beta"),
+		[]byte("name: workflow-dev, version: v2.0.0"),
 		"updated file")
 }

--- a/actions/release_walker.go
+++ b/actions/release_walker.go
@@ -39,7 +39,7 @@ func (r *releaseWalker) walk(path string, release releaseName, fi os.FileInfo, e
 	}
 
 	newContents := strings.Replace(string(read), "-dev", "-"+release.Short, -1)
-	newContents = strings.Replace(newContents, "v2-beta", release.Full, -1)
+	newContents = strings.Replace(newContents, "v2.0.0", release.Full, -1)
 
 	if _, err := fs.WriteFile(path, []byte(newContents), 0); err != nil {
 		log.Fatalf("Error writing contents to file %s (%s)", path, err)


### PR DESCRIPTION
As workflow-dev(-e2e) charts have had their version metadata
updated from `v2-beta` to `v2.0.0`

Ref https://github.com/deis/charts/pull/281