### PR TITLE
fix(Makefile): store versioned distribution builds in a subfolder of the bin dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ test-docker:
 	${DEV_ENV_CMD} sh -c '${GO_TEST_CMD}'
 
 build-cli-cross:
-	${DEV_ENV_CMD} gox -output="bin/${SHORT_NAME}-${VERSION}-{{.OS}}-{{.Arch}}"
+	${DEV_ENV_CMD} gox -output="bin/${VERSION}/${SHORT_NAME}-${VERSION}-{{.OS}}-{{.Arch}}"
 	${DEV_ENV_CMD} gox -output="bin/${SHORT_NAME}-latest-{{.OS}}-{{.Arch}}"
 
 dist: build-cli-cross


### PR DESCRIPTION
Fixes https://github.com/deis/deisrel/issues/92

Please see #92 for an explanation on what this fixes

# Associated [Documentation](https://github.com/deis/workflow) PR(s)

None required