### PR TITLE
chore(actions/common.go): update filename for e2e chart

### DIFF
--- a/actions/common.go
+++ b/actions/common.go
@@ -111,7 +111,7 @@ var (
 		Files: []string{
 			"README.md",
 			"Chart.yaml",
-			filepath.Join("tpl", "workflow-e2e-pod.yaml"),
+			filepath.Join("tpl", "generate_params.toml"),
 		},
 	}
 )


### PR DESCRIPTION
As location of e2e pod name will have changed in https://github.com/deis/charts/pull/299.
Therefore, this PR depends on https://github.com/deis/charts/pull/299 being merged.