### PR TITLE
fix(actions,docker): allowing tag & push to multiple registries

### DIFF
--- a/actions/docker/cmd.go
+++ b/actions/docker/cmd.go
@@ -38,7 +38,7 @@ func Command(ghClient *github.Client, dockerCl docker.Client) cli.Command {
 					cli.StringSliceFlag{
 						Name:  registriesFlag,
 						Value: &defaultDockerRegistriesStringSlice,
-						Usage: "The docker registries to tag and push to. An empty string means the docker hub",
+						Usage: "The docker registries to tag and push to. Use 'index.docker.io' to indicate the docker hub",
 					},
 				},
 				Action: retagCmd(ghClient, dockerCl),

--- a/actions/docker/cmd.go
+++ b/actions/docker/cmd.go
@@ -35,6 +35,11 @@ func Command(ghClient *github.Client, dockerCl docker.Client) cli.Command {
 						Value: "master",
 						Usage: "Optional ref to add to GitHub repo request (can be SHA, branch or tag)",
 					},
+					cli.StringSliceFlag{
+						Name:  registriesFlag,
+						Value: &defaultDockerRegistriesStringSlice,
+						Usage: "The docker registries to tag and push to. An empty string means the docker hub",
+					},
 				},
 				Action: retagCmd(ghClient, dockerCl),
 			},

--- a/actions/docker/retag.go
+++ b/actions/docker/retag.go
@@ -3,6 +3,7 @@ package docker
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/codegangsta/cli"
 	"github.com/deis/deisrel/actions"
@@ -12,9 +13,14 @@ import (
 )
 
 const (
-	newOrgFlag    = "new-org"
-	defaultNewOrg = "deis"
+	newOrgFlag     = "new-org"
+	defaultNewOrg  = "deis"
+	registriesFlag = "registries"
 )
+
+func getDockerRegistries(str string) []string {
+	return strings.Split(str, ",")
+}
 
 func getAllReposAndShas(
 	ghClient *github.Client,
@@ -96,6 +102,7 @@ func retagCmd(ghClient *github.Client, dockerCl docker.Client) func(c *cli.Conte
 		shaFilepath := c.String(actions.ShaFilepathFlag)
 		ref := c.String(actions.RefFlag)
 		promptPush := !c.Bool(actions.YesFlag)
+		registries := getDockerRegistries(c.String(registriesFlag))
 
 		allReposAndShas, err := getAllReposAndShas(ghClient, shaFilepath, ref)
 		if err != nil {
@@ -104,7 +111,7 @@ func retagCmd(ghClient *github.Client, dockerCl docker.Client) func(c *cli.Conte
 
 		repoAndShaList := git.NewRepoAndShaListFromSlice(allReposAndShas)
 		repoAndShaList.Sort()
-		images, err := docker.ParseImagesFromRepoAndShaList(docker.DeisCIDockerOrg, repoAndShaList)
+		images, err := docker.ParseImagesFromRepoAndShaList(registries, docker.DeisCIDockerOrg, repoAndShaList)
 		if err != nil {
 			log.Fatalf("Error parsing docker images (%s)", err)
 		}

--- a/actions/docker/retag.go
+++ b/actions/docker/retag.go
@@ -18,7 +18,7 @@ const (
 )
 
 var (
-	defaultDockerRegistriesStringSlice = cli.StringSlice([]string{"", "quay.io"})
+	defaultDockerRegistriesStringSlice = cli.StringSlice([]string{docker.DockerHubRegistry, "quay.io"})
 )
 
 func getAllReposAndShas(

--- a/actions/docker/retag.go
+++ b/actions/docker/retag.go
@@ -3,7 +3,6 @@ package docker
 import (
 	"fmt"
 	"log"
-	"strings"
 
 	"github.com/codegangsta/cli"
 	"github.com/deis/deisrel/actions"
@@ -18,9 +17,9 @@ const (
 	registriesFlag = "registries"
 )
 
-func getDockerRegistries(str string) []string {
-	return strings.Split(str, ",")
-}
+var (
+	defaultDockerRegistriesStringSlice = cli.StringSlice([]string{"", "quay.io"})
+)
 
 func getAllReposAndShas(
 	ghClient *github.Client,
@@ -102,7 +101,7 @@ func retagCmd(ghClient *github.Client, dockerCl docker.Client) func(c *cli.Conte
 		shaFilepath := c.String(actions.ShaFilepathFlag)
 		ref := c.String(actions.RefFlag)
 		promptPush := !c.Bool(actions.YesFlag)
-		registries := getDockerRegistries(c.String(registriesFlag))
+		registries := c.StringSlice(registriesFlag)
 
 		allReposAndShas, err := getAllReposAndShas(ghClient, shaFilepath, ref)
 		if err != nil {

--- a/docker/image.go
+++ b/docker/image.go
@@ -7,6 +7,10 @@ import (
 	"github.com/deis/deisrel/git"
 )
 
+const (
+	DockerHubRegistry = "index.docker.io"
+)
+
 // ErrInvalidImageName is the error returned when a func couldn't parse a string into an
 // Image struct
 type ErrInvalidImageName struct {
@@ -65,7 +69,8 @@ func ParseImageFromName(name string) (*Image, error) {
 }
 
 // ParseImageFromRepoAndSha attempts to convert ras into a set of docker images, each of which
-// points to a registry in registries and uses dockerRegistryOrg.
+// points to a registry in registries and uses dockerRegistryOrg. Any registry that matches
+// DockerHubRegistry will be converted to empty
 func ParseImageFromRepoAndSha(
 	dockerRegistries []string,
 	dockerRegistryOrg string,
@@ -74,6 +79,9 @@ func ParseImageFromRepoAndSha(
 	ret := make([]*Image, len(dockerRegistries))
 	for i, reg := range dockerRegistries {
 		str := fmt.Sprintf("%s/%s:git-%s", dockerRegistryOrg, ras.Name, ras.ShortSHA())
+		if reg == DockerHubRegistry {
+			reg = ""
+		}
 		if reg != "" {
 			// prepend the registry if it's non-empty
 			str = fmt.Sprintf("%s/%s", reg, str)

--- a/docker/image.go
+++ b/docker/image.go
@@ -64,25 +64,47 @@ func ParseImageFromName(name string) (*Image, error) {
 	return nil, ErrInvalidImageName{Str: name}
 }
 
-// ParseImageFromRepoAndSha attempts to convert ras into a docker image, using
-// dockerRegistryOrg as the docker registry
-func ParseImageFromRepoAndSha(dockerRegistryOrg string, ras git.RepoAndSha) (*Image, error) {
-	str := fmt.Sprintf("quay.io/%s/%s:git-%s", dockerRegistryOrg, ras.Name, ras.SHA)
-	return ParseImageFromName(str)
+// ParseImageFromRepoAndSha attempts to convert ras into a set of docker images, each of which
+// points to a registry in registries and uses dockerRegistryOrg.
+func ParseImageFromRepoAndSha(
+	dockerRegistries []string,
+	dockerRegistryOrg string,
+	ras git.RepoAndSha,
+) ([]*Image, error) {
+	ret := make([]*Image, len(dockerRegistries))
+	for i, reg := range dockerRegistries {
+		str := fmt.Sprintf("%s/%s:git-%s", dockerRegistryOrg, ras.Name, ras.ShortSHA())
+		if reg != "" {
+			// prepend the registry if it's non-empty
+			str = fmt.Sprintf("%s/%s", reg, str)
+		}
+		img, err := ParseImageFromName(str)
+		if err != nil {
+			return nil, err
+		}
+		ret[i] = img
+	}
+	return ret, nil
 }
 
 // ParseImagesFromRepoAndShaList returns a slice of parsed Images in the same order as they
 // appear in rasl.Slice(). Returns an empty slice and a non-nil error if any one of the
 // git.RepoAndShas couldn't be parsed
-func ParseImagesFromRepoAndShaList(dockerRegistryOrg string, rasl *git.RepoAndShaList) ([]*Image, error) {
+func ParseImagesFromRepoAndShaList(
+	dockerRegistries []string,
+	dockerRegistryOrg string,
+	rasl *git.RepoAndShaList,
+) ([]*Image, error) {
 	raslSlice := rasl.Slice()
-	ret := make([]*Image, len(raslSlice))
-	for i, ras := range raslSlice {
-		img, err := ParseImageFromRepoAndSha(dockerRegistryOrg, ras)
+	ret := []*Image{}
+	for _, ras := range raslSlice {
+		imgs, err := ParseImageFromRepoAndSha(dockerRegistries, dockerRegistryOrg, ras)
 		if err != nil {
 			return nil, err
 		}
-		ret[i] = img
+		for _, img := range imgs {
+			ret = append(ret, img)
+		}
 	}
 	return ret, nil
 }

--- a/docker/image_test.go
+++ b/docker/image_test.go
@@ -43,13 +43,17 @@ func TestParseImageFromName(t *testing.T) {
 }
 
 func TestParseImageFromRepoAndSha(t *testing.T) {
-	registries := []string{"", "quay.io"}
+	registries := []string{"", DockerHubRegistry, "quay.io"}
 	const org = "regorg"
 	ras := git.RepoAndSha{Name: "testRepo", SHA: "testSHA"}
 	imgs, err := ParseImageFromRepoAndSha(registries, org, ras)
 	assert.NoErr(t, err)
 	assert.Equal(t, len(imgs), len(registries), "number of returned images")
 	for i, img := range imgs {
-		assert.Equal(t, img.registry, registries[i], fmt.Sprintf("registry for image %d", i))
+		expectedReg := registries[i]
+		if expectedReg == DockerHubRegistry {
+			expectedReg = ""
+		}
+		assert.Equal(t, img.registry, expectedReg, fmt.Sprintf("registry for image %d", i))
 	}
 }

--- a/docker/image_test.go
+++ b/docker/image_test.go
@@ -1,7 +1,11 @@
 package docker
 
 import (
+	"fmt"
 	"testing"
+
+	"github.com/arschles/assert"
+	"github.com/deis/deisrel/git"
 )
 
 func createTestImages() []*Image {
@@ -35,5 +39,17 @@ func TestParseImageFromName(t *testing.T) {
 			t.Errorf("case %d expected %s but got %s", i, *testCase.Expected, *parsed)
 			continue
 		}
+	}
+}
+
+func TestParseImageFromRepoAndSha(t *testing.T) {
+	registries := []string{"", "quay.io"}
+	const org = "regorg"
+	ras := git.RepoAndSha{Name: "testRepo", SHA: "testSHA"}
+	imgs, err := ParseImageFromRepoAndSha(registries, org, ras)
+	assert.NoErr(t, err)
+	assert.Equal(t, len(imgs), len(registries), "number of returned images")
+	for i, img := range imgs {
+		assert.Equal(t, img.registry, registries[i], fmt.Sprintf("registry for image %d", i))
 	}
 }


### PR DESCRIPTION
Fixes #107 

Adds a new `--registries` flag, which can be specified multiple times, to indicate all of the docker registries that the caller would like to pull from. For example:

```console
./deisrel docker retag --yes=false --ref=v2.0.0 --registries="index.docker.io" --registries="quay.io" workflow-2.1.0
```

# Associated [Documentation](https://github.com/deis/workflow) PR(s)

None required. This change will automatically pull from, tag and push to both quay.io and the docker hub