### PR TITLE
feat(main.go,git,actions): add GH create branches command

### DIFF
--- a/actions/branches/cmd.go
+++ b/actions/branches/cmd.go
@@ -1,0 +1,42 @@
+package branches
+
+import (
+	"github.com/codegangsta/cli"
+	"github.com/deis/deisrel/actions"
+	"github.com/google/go-github/github"
+)
+
+const (
+	branchNameFlag = "name"
+)
+
+// Command returns the CLI command for all 'deisrel branches ...' commands
+func Command(ghClient *github.Client) cli.Command {
+	return cli.Command{
+		Name: "branches",
+		Subcommands: []cli.Command{
+			cli.Command{
+				Name:        "create",
+				Usage:       "Create branches on all repositories that are part of the Deis Workflow platform.",
+				Description: "This command creates branches on all repositories that are part of the Deis Workflow platform",
+				Flags: []cli.Flag{
+					cli.StringFlag{
+						Name:  branchNameFlag,
+						Value: "",
+						Usage: "The name of the branch to create on all repositories",
+					},
+					cli.BoolFlag{
+						Name:  actions.YesFlag,
+						Usage: "Whether to proceed with branch creation. Pass false to do a dry run",
+					},
+					cli.StringFlag{
+						Name:  actions.RefFlag,
+						Value: "master",
+						Usage: "The ref (branch or SHA) to branch from.",
+					},
+				},
+				Action: createCmd(ghClient),
+			},
+		},
+	}
+}

--- a/actions/branches/create.go
+++ b/actions/branches/create.go
@@ -1,0 +1,48 @@
+package branches
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/codegangsta/cli"
+	"github.com/deis/deisrel/actions"
+	"github.com/deis/deisrel/git"
+	"github.com/google/go-github/github"
+)
+
+func createCmd(ghClient *github.Client) func(c *cli.Context) error {
+	return func(c *cli.Context) error {
+		branchName := c.String(branchNameFlag)
+		if branchName == "" {
+			log.Fatalf("Branch name not specified")
+		}
+		proceed := c.Bool(actions.YesFlag)
+		ref := c.String(actions.RefFlag)
+
+		repoNames := git.RepoNames()
+		fmt.Printf("Getting SHAs for all repositories on '%s'\n", ref)
+		reposAndSHAs, err := git.GetSHAs(ghClient, repoNames, git.NoTransform, ref)
+		if err != nil {
+			log.Fatalf("Error getting SHAs for repositories (%s)", err)
+		}
+		for _, ras := range reposAndSHAs {
+			fmt.Printf("%s - %s\n", ras.Name, ras.SHA)
+		}
+
+		fmt.Println()
+		fmt.Printf("Creating branch %s on all repositories\n", branchName)
+		if proceed {
+			rasl, err := git.CreateBranches(ghClient, branchName, reposAndSHAs)
+			if err != nil {
+				log.Fatalf("Error creating branches for repositories (%s)", err)
+			}
+
+			for _, ras := range rasl {
+				fmt.Printf("Created branch %s on %s\n", branchName, ras.Name)
+			}
+		} else {
+			fmt.Printf("Not creating branches. '%s' flag was false\n", actions.YesFlag)
+		}
+		return nil
+	}
+}

--- a/docker/push_test.go
+++ b/docker/push_test.go
@@ -1,7 +1,6 @@
 package docker
 
 import (
-	"strconv"
 	"testing"
 
 	"github.com/arschles/assert"
@@ -21,7 +20,12 @@ func TestPushImages(t *testing.T) {
 	errs := PushImages(memCl, images)
 	assert.Equal(t, len(errs), 0, "number of errors")
 	assert.Equal(t, len(memCl.Pushes), len(images), "number of pushes received")
+	pushMap := make(map[string]struct{})
+	for _, push := range memCl.Pushes {
+		pushMap[push.String()] = struct{}{}
+	}
 	for i, img := range images {
-		assert.Equal(t, *img, *memCl.Pushes[i], "pushed image "+strconv.Itoa(i))
+		_, ok := pushMap[img.String()]
+		assert.True(t, ok, "image %d (%s) wasn't pushed", i, img.String())
 	}
 }

--- a/git/create_branches.go
+++ b/git/create_branches.go
@@ -1,0 +1,51 @@
+package git
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/google/go-github/github"
+)
+
+// CreateBranches creates branches called branchName in all of the repos listed in reposAndSHAs,
+// each from the given SHA in that element. Returns a slice of RepoAndSha, each with the repo name
+// and sha given. The returned slice will not necessarily be in the same order as reposAndSHAs.
+// Finally, this func returns a nil slice and a non-nil error if any create branch operation failed
+func CreateBranches(ghClient *github.Client, branchName string, reposAndSHAs []RepoAndSha) ([]RepoAndSha, error) {
+	var wg sync.WaitGroup
+	rasCh := make(chan RepoAndSha)
+	errCh := make(chan error)
+	doneCh := make(chan struct{})
+	for _, ras := range reposAndSHAs {
+		refName := fmt.Sprintf("refs/heads/%s", branchName)
+		wg.Add(1)
+		go func(ras RepoAndSha, refName string) {
+			defer wg.Done()
+			_, _, err := ghClient.Git.CreateRef("deis", ras.Name, &github.Reference{
+				Ref: &refName,
+			})
+			if err != nil {
+				errCh <- err
+				return
+			}
+			rasCh <- ras
+		}(ras, refName)
+	}
+
+	go func() {
+		wg.Wait()
+		close(doneCh)
+	}()
+
+	ret := []RepoAndSha{}
+	for {
+		select {
+		case err := <-errCh:
+			return nil, err
+		case ras := <-rasCh:
+			ret = append(ret, ras)
+		case <-doneCh:
+			return ret, nil
+		}
+	}
+}

--- a/git/create_branches.go
+++ b/git/create_branches.go
@@ -21,10 +21,11 @@ func CreateBranches(ghClient *github.Client, branchName string, reposAndSHAs []R
 		wg.Add(1)
 		go func(ras RepoAndSha, refName string) {
 			defer wg.Done()
-			_, _, err := ghClient.Git.CreateRef("deis", ras.Name, &github.Reference{
-				Ref: &refName,
-			})
-			if err != nil {
+			if _, _, err := ghClient.Git.CreateRef(
+				"deis",
+				ras.Name,
+				newBranchReference("deis", ras.Name, branchName, ras.SHA),
+			); err != nil {
 				errCh <- err
 				return
 			}

--- a/git/create_branches_test.go
+++ b/git/create_branches_test.go
@@ -1,0 +1,43 @@
+package git
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/arschles/assert"
+	"github.com/deis/deisrel/testutil"
+)
+
+func TestCreateBranches(t *testing.T) {
+	const (
+		orgName  = "deis"
+		repoName = "controller"
+		branch   = "testbranch"
+		commit   = "aa218f56b14c9653891f9e74264a383fa43fefbd"
+	)
+	ts := testutil.NewTestServer()
+	defer ts.Close()
+	ts.Mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/git/refs", orgName, repoName), func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "POST", "request method")
+		ret := fmt.Sprintf(`
+    {
+      "ref": "refs/heads/%s",
+      "url": "https://api.github.com/repos/%s/%s/git/refs/heads/%s",
+      "object": {
+        "type": "commit",
+        "sha": "%s",
+        "url": "https://api.github.com/repos/%s/%s/git/commits/%s"
+      }
+    }`, branch, orgName, repoName, branch, commit, orgName, repoName, commit)
+		fmt.Fprintf(w, ret)
+	})
+
+	rasl := []RepoAndSha{
+		RepoAndSha{Name: repoName, SHA: "master"},
+	}
+	retRasl, err := CreateBranches(ts.Client, branch, rasl)
+	assert.NoErr(t, err)
+	assert.Equal(t, len(retRasl), len(rasl), "number of returned RepoAndSha structs")
+	assert.Equal(t, retRasl[0], rasl[0], "returned RepoAndSha")
+}

--- a/git/create_branches_test.go
+++ b/git/create_branches_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -20,17 +21,8 @@ func TestCreateBranches(t *testing.T) {
 	defer ts.Close()
 	ts.Mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/git/refs", orgName, repoName), func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, r.Method, "POST", "request method")
-		ret := fmt.Sprintf(`
-    {
-      "ref": "refs/heads/%s",
-      "url": "https://api.github.com/repos/%s/%s/git/refs/heads/%s",
-      "object": {
-        "type": "commit",
-        "sha": "%s",
-        "url": "https://api.github.com/repos/%s/%s/git/commits/%s"
-      }
-    }`, branch, orgName, repoName, branch, commit, orgName, repoName, commit)
-		fmt.Fprintf(w, ret)
+		retRef := newBranchReference(orgName, repoName, branch, commit)
+		assert.NoErr(t, json.NewEncoder(w).Encode(retRef))
 	})
 
 	rasl := []RepoAndSha{

--- a/git/ref.go
+++ b/git/ref.go
@@ -1,0 +1,19 @@
+package git
+
+import (
+	"fmt"
+
+	"github.com/google/go-github/github"
+)
+
+func newBranchReference(orgName, repoName, branchName, sha string) *github.Reference {
+	return &github.Reference{
+		Ref: github.String(fmt.Sprintf("refs/heads/%s", branchName)),
+		URL: github.String(fmt.Sprintf("https://api.github.com/repos/%s/%s/git/refs/heads/%s", orgName, repoName, branchName)),
+		Object: &github.GitObject{
+			Type: github.String("commit"),
+			SHA:  github.String(sha),
+			URL:  github.String(fmt.Sprintf("https://api.github.com/repos/%s/%s/git/commits/%s", orgName, repoName, sha)),
+		},
+	}
+}

--- a/git/ref_test.go
+++ b/git/ref_test.go
@@ -1,0 +1,34 @@
+package git
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/arschles/assert"
+)
+
+func TestNewBranchReference(t *testing.T) {
+	const (
+		orgName    = "testorg"
+		repoName   = "testrepo"
+		branchName = "testbranch"
+		sha        = "testsha"
+	)
+
+	ref := newBranchReference(orgName, repoName, branchName, sha)
+	assert.Equal(t, *ref.Ref, fmt.Sprintf("ref/heads/%s", sha), "sha")
+	assert.Equal(
+		t,
+		*ref.URL,
+		fmt.Sprintf("https://api.github.com/repos/%s/%s/git/refs/heads/%s", orgName, repoName, branchName),
+		"url",
+	)
+	assert.Equal(t, *ref.Object.Type, "commit", "object type")
+	assert.Equal(t, *ref.Object.SHA, sha, "sha")
+	assert.Equal(
+		t,
+		*ref.Object.URL,
+		fmt.Sprintf("https://api.github.com/repos/%s/%s/git/commits/%s", orgName, repoName, sha),
+		"url",
+	)
+}

--- a/git/ref_test.go
+++ b/git/ref_test.go
@@ -16,7 +16,7 @@ func TestNewBranchReference(t *testing.T) {
 	)
 
 	ref := newBranchReference(orgName, repoName, branchName, sha)
-	assert.Equal(t, *ref.Ref, fmt.Sprintf("ref/heads/%s", sha), "sha")
+	assert.Equal(t, *ref.Ref, fmt.Sprintf("refs/heads/%s", branchName), "sha")
 	assert.Equal(
 		t,
 		*ref.URL,

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/codegangsta/cli"
 	"github.com/deis/deisrel/actions"
+	"github.com/deis/deisrel/actions/branches"
 	"github.com/deis/deisrel/actions/docker"
 	dlib "github.com/deis/deisrel/docker"
 	"github.com/google/go-github/github"
@@ -34,6 +35,7 @@ func main() {
 	app.Version = version
 	app.Commands = []cli.Command{
 		docker.Command(ghClient, dockerCl),
+		branches.Command(ghClient),
 		cli.Command{
 			Name: "git",
 			Subcommands: []cli.Command{


### PR DESCRIPTION
Fixes #99 

TODO: 

- [x] Unit tests
- [x] Documentation PR (see below section)

Usage:

```console
ENG000656:deisrel aaronschlesinger$ ./deisrel branches create --name="test" --yes=false --ref="master"
Getting SHAs for all repositories on 'master'
postgres - f745e74d620a8d1847da20be8d6221aeaa8ea4c4
stdout-metrics - c37e3ec5390222e5f773ad2a7b4fc19cd0ca23f2
controller - c65c5083104780c3d7c5993a23dc7fdb9b2bf4b9
builder - a0905cc68aaae32d1f3c52da9ced33deed1a84ec
fluentd - 0c5dc2146bdb2c11691778ddece38d6a53e9c629
workflow-manager - af9ef041b2b04cb013e7c7d659a85af478048ea2
registry - 8528182f7785489cdf1e257faa2deaf0878b9f22
minio - ba66283177efd6f98cb665e44c4b565e2dc35896
slugrunner - 624d8a38ef0b2cceb5d9b7908d81ec602900f732
workflow-e2e - 08d5322607cbf8bef7dad9bcd8ae1cecf5b616e0
monitor - 14d6af08d14188b2b08f9d280b5a5cdffa00aca5
logger - 80f43f4752864943a63a4e281b5b53475c2d9f0a
slugbuilder - fc39aa7fe2c4dc18f349ccefcbdc88a98a49363a
dockerbuilder - 84ef6302fe4cf595d9154383902a5ccfcca893a7
router - af5c2580248e8e2ab83df9fc6669d91bdb27d516

Creating branch test on all repositories
Not creating branches. 'yes' flag was false
```

# Associated [Documentation](https://github.com/deis/workflow) PR(s)

https://github.com/deis/workflow/pull/365