### PR TITLE
chore(common.go): add workflow-cli to additional git repos

### DIFF
--- a/actions/common.go
+++ b/actions/common.go
@@ -51,7 +51,7 @@ var (
 	// additionalGitRepoNames represents the repo names lacking representation
 	// in any helm chart, yet still requiring updates during each Workflow
 	// release, including changelog generation and creation of git tags.
-	additionalGitRepoNames = []string{"workflow", "charts"}
+	additionalGitRepoNames = []string{"workflow", "charts", "workflow-cli"}
 
 	// allGitRepoNames represent all GitHub repo names needing git-based updates for a release
 	allGitRepoNames = append(git.RepoNames(), additionalGitRepoNames...)


### PR DESCRIPTION
so that git operations related to a release are also done for this repo

This is also necessary so that the https://ci.deis.io/job/workflow-cli-tag-release/ job receives the tag push event for it to run.