### PR TITLE
chore(Makefile): update to go-dev 0.17.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,9 @@ else
 endif
 
 REPO_PATH := github.com/deis/${SHORT_NAME}
-DEV_ENV_IMAGE := quay.io/deis/go-dev:0.14.0
+DEV_ENV_IMAGE := quay.io/deis/go-dev:0.17.0
 DEV_ENV_WORK_DIR := /go/src/${REPO_PATH}
-DEV_ENV_PREFIX := docker run --rm -e GO15VENDOREXPERIMENT=1 -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR}
+DEV_ENV_PREFIX := docker run --rm -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR}
 DEV_ENV_CMD := ${DEV_ENV_PREFIX} ${DEV_ENV_IMAGE}
 
 DEIS_BINARY_NAME ?= ./deis


### PR DESCRIPTION
Includes the go 1.7 toolchain. See https://tip.golang.org/doc/go1.7.