### PR TITLE
fix(main.go): require `GITHUB_ACCESS_TOKEN` to be set

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ workflowManager v2.2.0 -> v2.2.0 (clean)
 
 It's also possible to output the report in json using the `-o json` argument for easier machine parsing.
 
-Github has a very low ratelimit for unauthenticated api requests. A personal oauth token can be used to bypass this restriction. Create an oauth token with no permission and set it to `$GH_TOKEN` and deisrel will
+Github has a very low ratelimit for unauthenticated api requests. A "[personal access token][]" can be used to bypass this restriction. Create a GitHub token with "repo" permission and set it to `$GITHUB_ACCESS_TOKEN`. `deisrel` will
 use it when making requests.
 
 # Development
@@ -122,5 +122,6 @@ Unless required by applicable law or agreed to in writing, software distributed 
 
 
 [issues]: https://github.com/deis/deisrel/issues
+[personal access token]: https://github.com/settings/tokens
 [prs]: https://github.com/deis/deisrel/pulls
 [workflow]: https://github.com/deis/workflow

--- a/main.go
+++ b/main.go
@@ -19,18 +19,21 @@ import (
 var version = "0.0.0" // replaced when building
 
 func main() {
-	ghclient := github.NewClient(nil)
+	app := cli.NewApp()
 
-	if token, ok := os.LookupEnv("GH_TOKEN"); ok {
-		ts := oauth2.StaticTokenSource(
-			&oauth2.Token{AccessToken: token},
-		)
-		ghclient = github.NewClient(oauth2.NewClient(oauth2.NoContext, ts))
+	token, ok := os.LookupEnv("GITHUB_ACCESS_TOKEN")
+	if !ok {
+		fmt.Println("\"GITHUB_ACCESS_TOKEN\" must be set to a valid GitHub access token.")
+		os.Exit(1)
 	}
 
-	app := cli.NewApp()
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: token},
+	)
+	ghclient := github.NewClient(oauth2.NewClient(oauth2.NoContext, ts))
+
 	app.Name = "deisrel"
-	app.Usage = "Manage deis workflow releases. If you need to bypass the github ratelimit, add set github oauth token (no permissions required) to $GH_TOKEN"
+	app.Usage = "Manage deis workflow releases."
 	app.UsageText = "deisrel [options] <chart versions> <repo map>"
 	app.Version = version
 	app.Flags = []cli.Flag{


### PR DESCRIPTION
The token is (almost) mandatory, and this env var is more standard than `GH_TOKEN`.

Closes #144.