### PR TITLE
ref(*): fix changelog global command

### DIFF
--- a/actions/generate_changelog_err.go
+++ b/actions/generate_changelog_err.go
@@ -1,0 +1,13 @@
+package actions
+
+import (
+	"fmt"
+)
+
+type errComponentVersionNotFound struct {
+	componentName string
+}
+
+func (e errComponentVersionNotFound) Error() string {
+	return fmt.Sprintf("A ComponentVersion for component named '%s' not found.", e.componentName)
+}

--- a/changelog/changelog_test.go
+++ b/changelog/changelog_test.go
@@ -136,13 +136,15 @@ func TestTemplate(t *testing.T) {
 }
 
 func TestMergeValues(t *testing.T) {
-	val1 := Values{Features: []string{"feat1"}}
-	val2 := Values{Fixes: []string{"fix1"}, Features: []string{"feat2"}}
-	res := MergeValues("old", "new", []Values{val1, val2})
+	val1 := Values{RepoName: "repo-a", OldRelease: "v1.2.3", NewRelease: "v1.2.4", Features: []string{"feat1"}}
+	val2 := Values{RepoName: "repo-b", OldRelease: "v4.5.6", NewRelease: "v4.6.0", Fixes: []string{"fix1"}, Features: []string{"feat2"}}
+	val3 := Values{OldRelease: "v1.2.3", NewRelease: "v1.2.3"} // no change; should not be added to res.Releases
+	res := MergeValues("old", "new", []Values{val1, val2, val3})
 	assert.Equal(t, res.OldRelease, "old", "old release")
 	assert.Equal(t, res.NewRelease, "new", "new release")
 	assert.Equal(t, len(res.Features), 2, "length of features slice")
 	assert.Equal(t, len(res.Fixes), 1, "length of fixes slice")
 	assert.Equal(t, res.Features, []string{"feat1", "feat2"}, "features slice")
 	assert.Equal(t, res.Fixes, []string{"fix1"}, "fixes slice")
+	assert.Equal(t, res.Releases, []string{"repo-a v1.2.3 -> v1.2.4", "repo-b v4.5.6 -> v4.6.0"}, "releases slice")
 }

--- a/changelog/single_repo_err.go
+++ b/changelog/single_repo_err.go
@@ -10,7 +10,7 @@ type errTagNotFoundForRepo struct {
 }
 
 func (e errTagNotFoundForRepo) Error() string {
-	return fmt.Sprintf("tag %s not found for repo %s", e.tagName, e.repoName)
+	return fmt.Sprintf("tag %s not found for repo %s; Changelog entries will need to be added in manually", e.tagName, e.repoName)
 }
 
 type errCouldNotCompareCommits struct {

--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func main() {
 				cli.Command{
 					Name:        "global",
 					Action:      actions.GenerateChangelog(ghclient, os.Stdout),
-					Usage:       "deisrel changelog global <repo map> <old-release> <new-release>",
+					Usage:       "deisrel changelog global <previous chart release params file> <repo map>",
 					Description: "Aggregate changelog entries from all known repositories for a specified release",
 				},
 				cli.Command{


### PR DESCRIPTION
To compensate for individual components now following their own release cadences.

**Notes:** 
* this goes back to the changelog format used in `v2.0.0`-`v2.3.0` Workflow releases such as [v2.2.0](https://deis.com/docs/workflow/changelogs/v2.2.0/) (with the addition of alphabetical ordering!) as opposed to the more recent/manually assembled format as seen in the latest [v2.8.0 release](https://deis.com/docs/workflow/changelogs/v2.8.0/)

* since the `deisrel changelog global` command now takes the previous Workflow release's `generate_params.toml` (for discerning each component's version migration) and as that file does not contain info on the `workflow`, `workflow-cli` and `workflow-e2e` repos, we are unable to add changelog entries with the code as it is now.  (Would welcome ideas on how to address this, perhaps in a follow-up issue.)  Warnings will be printed like:
```
2016/10/31 12:23:10 Error: tag unknown not found for repo workflow; Changelog entries will need to be added in manually
2016/10/31 12:23:10 Error: tag unknown not found for repo workflow-e2e; Changelog entries will need to be added in manually
2016/10/31 12:23:10 Error: tag unknown not found for repo workflow-cli; Changelog entries will need to be added in manually
```

If/when this PR starts to become a merge candidate, I'll create the associated PR in deis/workflow.

TODO:
- [x] Reference correlating deis/workflow docs PR: https://github.com/deis/workflow/pull/594
