### PR TITLE
feat(*): show skipped commits in full changelog format

### DIFF
--- a/actions/generate_individual_changelog.go
+++ b/actions/generate_individual_changelog.go
@@ -50,8 +50,9 @@ func GenerateIndividualChangelog(client *github.Client, dest io.Writer) func(*cl
 		skippedCommits, err := changelog.SingleRepoVals(client, vals, sha, repoName, false)
 
 		if len(skippedCommits) > 0 {
+			fmt.Fprintln(os.Stderr, "skipping the following commits:")
 			for _, ci := range skippedCommits {
-				fmt.Fprintln(os.Stderr, "skipping commit", ci)
+				fmt.Fprintln(os.Stderr, "-", ci)
 			}
 		}
 

--- a/changelog/single_repo.go
+++ b/changelog/single_repo.go
@@ -57,7 +57,7 @@ func SingleRepoVals(client *github.Client, vals *Values, sha, name string, inclu
 		} else if strings.HasPrefix(commitMessage, "chore(") {
 			vals.Maintenance = append(vals.Maintenance, changelogMessage)
 		} else {
-			skippedCommits = append(skippedCommits, *commit.SHA)
+			skippedCommits = append(skippedCommits, changelogMessage)
 		}
 	}
 	return skippedCommits, nil


### PR DESCRIPTION
Currently via `--show-skipped-commits` flag.  

However, I might also propose we go further and remove this new option and just show the full skipped changelog message as a default -- I find it helps to be sure all skipped commits indeed should not be included.  

For example, compare the two (original sha-only format first):

```
$ ./deisrel changelog individual workflow unknown
skipping the following commits:
- 6f1c46686e889d0f09af5878fa924577db5d3351
- 027509f3fb79904dbe9c974357e3c97a711fc077
- 1d70f53f1748981e7aa40e71948cdd76b56b53ca
- 6a620266d3e160a53d9a3278f9e01f818dad9d7e
- 3b5069dfde8ed7cc448a45825401549a14b5ad4a
- f2f270b486ab9b64ca7c71188b22365a9fd55d1a
- bc54566d6b9167191301cf2e8f05fc0ab1ec7324
- 5c52d0430604c3149fd382252a9bd9121dbe32b3
...
```

```
$ ./deisrel changelog individual workflow unknown --show-skipped-commits
skipping the following commits:
- [`6f1c466`](https://github.com/deis/workflow/commit/6f1c46686e889d0f09af5878fa924577db5d3351) *: Merge pull request #579 from kmala/charts
- [`027509f`](https://github.com/deis/workflow/commit/027509f3fb79904dbe9c974357e3c97a711fc077) *: Merge pull request #578 from mboersma/contrib-projects
- [`1d70f53`](https://github.com/deis/workflow/commit/1d70f53f1748981e7aa40e71948cdd76b56b53ca) *: Merge pull request #581 from mboersma/fix-objectstorage-link
- [`6a62026`](https://github.com/deis/workflow/commit/6a620266d3e160a53d9a3278f9e01f818dad9d7e) *: Merge pull request #582 from vdice/release-v2.8.0-doc-update
- [`3b5069d`](https://github.com/deis/workflow/commit/3b5069dfde8ed7cc448a45825401549a14b5ad4a) *: Merge pull request #588 from kmala/doc
- [`f2f270b`](https://github.com/deis/workflow/commit/f2f270b486ab9b64ca7c71188b22365a9fd55d1a) index: word wrap to 99 characters
- [`bc54566`](https://github.com/deis/workflow/commit/bc54566d6b9167191301cf2e8f05fc0ab1ec7324) *: Merge pull request #592 from bacongobbler/contributing-to-homepage
- [`5c52d04`](https://github.com/deis/workflow/commit/5c52d0430604c3149fd382252a9bd9121dbe32b3) *: Merge pull request #535 from mboersma/automate-component-release
...
```

We'd then want to include the one incorrectly skipped commit into the changelog, and it's all set for the copy/paste:
```
- [`f2f270b`](https://github.com/deis/workflow/commit/f2f270b486ab9b64ca7c71188b22365a9fd55d1a) index: word wrap to 99 characters
```

Otherwise, if consensus endorses the new flag, that's fine too.  I can make a note in the release docs...

TODO
 - [ ] correlating docs PR, if necessary

