### PR TITLE
fix(single_repo.go): pass in skippedCommits slice

### DIFF
--- a/changelog/single_repo.go
+++ b/changelog/single_repo.go
@@ -45,7 +45,7 @@ func SingleRepoVals(client *github.Client, vals *Values, sha, name string, inclu
 			changelogMessage = fmt.Sprintf("%s (%s) - %s: %s", shortSHALink, name, focus, title)
 		}
 
-		skippedCommits = appendToValues(vals, commitMessage, changelogMessage)
+		skippedCommits = appendToValues(vals, commitMessage, changelogMessage, skippedCommits)
 	}
 	return skippedCommits, nil
 }
@@ -60,10 +60,8 @@ func shortSHATransform(s string) (string, error) {
 }
 
 // appendToValues appends a changelogMessage to vals depending on commitMessage,
-// returning any skipped commits
-func appendToValues(vals *Values, commitMessage, changelogMessage string) []string {
-	var skippedCommits []string
-
+// returning any skipped commits (which will be appended to the provided skippedCommits)
+func appendToValues(vals *Values, commitMessage, changelogMessage string, skippedCommits []string) []string {
 	if strings.HasPrefix(commitMessage, "feat(") {
 		vals.Features = append(vals.Features, changelogMessage)
 	} else if strings.HasPrefix(commitMessage, "ref(") {
@@ -77,7 +75,7 @@ func appendToValues(vals *Values, commitMessage, changelogMessage string) []stri
 	} else if strings.HasPrefix(commitMessage, "chore(") {
 		vals.Maintenance = append(vals.Maintenance, changelogMessage)
 	} else {
-		if (!strings.HasPrefix(commitMessage, "Merge pull request")) {
+		if !strings.HasPrefix(commitMessage, "Merge pull request") {
 			skippedCommits = append(skippedCommits, changelogMessage)
 		}
 	}

--- a/changelog/single_repo_test.go
+++ b/changelog/single_repo_test.go
@@ -7,62 +7,78 @@ import (
 )
 
 func TestAppendToValues(t *testing.T) {
-  changelogMessage := "changelog message"
+	changelogMessage := "changelog message"
 
-  type testCase struct {
-    commitMessage    string
-    vals     *Values
-    skippedCommits   []string
-  }
+	type testCase struct {
+		commitMessage  string
+		vals           *Values
+		skippedCommits []string
+	}
 
-  testCases := []testCase{
-    testCase{
-      commitMessage: "Merge pull request",
-      vals: &Values{},
-      skippedCommits: []string{},
-    },
-    testCase{
-      commitMessage: "skipped commit",
-      vals: &Values{},
-      skippedCommits: []string{changelogMessage},
-    },
-    testCase{
-      commitMessage: "chore()",
-      vals: &Values{Maintenance: []string{changelogMessage}},
-      skippedCommits: []string{},
-    },
-    testCase{
-      commitMessage: "docs()",
-      vals: &Values{Documentation: []string{changelogMessage}},
-      skippedCommits: []string{},
-    },
-    testCase{
-      commitMessage: "feat()",
-      vals: &Values{Features: []string{changelogMessage}},
-      skippedCommits: []string{},
-    },
-    testCase{
-      commitMessage: "fix()",
-      vals: &Values{Fixes: []string{changelogMessage}},
-      skippedCommits: []string{},
-    },
-    testCase{
-      commitMessage: "ref()",
-      vals: &Values{Refactors: []string{changelogMessage}},
-      skippedCommits: []string{},
-    },
-    testCase{
-      commitMessage: "test()",
-      vals: &Values{Tests: []string{changelogMessage}},
-      skippedCommits: []string{},
-    },
-  }
+	testCases := []testCase{
+		testCase{
+			commitMessage:  "Merge pull request",
+			vals:           &Values{},
+			skippedCommits: []string{},
+		},
+		testCase{
+			commitMessage:  "skipped commit",
+			vals:           &Values{},
+			skippedCommits: []string{changelogMessage},
+		},
+		testCase{
+			commitMessage:  "chore()",
+			vals:           &Values{Maintenance: []string{changelogMessage}},
+			skippedCommits: []string{},
+		},
+		testCase{
+			commitMessage:  "docs()",
+			vals:           &Values{Documentation: []string{changelogMessage}},
+			skippedCommits: []string{},
+		},
+		testCase{
+			commitMessage:  "feat()",
+			vals:           &Values{Features: []string{changelogMessage}},
+			skippedCommits: []string{},
+		},
+		testCase{
+			commitMessage:  "fix()",
+			vals:           &Values{Fixes: []string{changelogMessage}},
+			skippedCommits: []string{},
+		},
+		testCase{
+			commitMessage:  "ref()",
+			vals:           &Values{Refactors: []string{changelogMessage}},
+			skippedCommits: []string{},
+		},
+		testCase{
+			commitMessage:  "test()",
+			vals:           &Values{Tests: []string{changelogMessage}},
+			skippedCommits: []string{},
+		},
+	}
 
-  for _, testCase := range testCases {
-    vals := &Values{}
-    skippedCommits := appendToValues(vals, testCase.commitMessage, changelogMessage)
+	for _, testCase := range testCases {
+		var skippedCommits []string
+		vals := &Values{}
+		skippedCommits = appendToValues(vals, testCase.commitMessage, changelogMessage, skippedCommits)
 
-    assert.Equal(t, len(skippedCommits), len(testCase.skippedCommits), "skipped commits length")
-    assert.Equal(t, vals, testCase.vals, "vals")
-  }
+		assert.Equal(t, len(skippedCommits), len(testCase.skippedCommits), "skipped commits length")
+		assert.Equal(t, vals, testCase.vals, "vals")
+	}
+}
+
+func TestAppendToValuesMultipleSkippedCommits(t *testing.T) {
+	var skippedCommits []string
+	changelogMessage := "changelog message"
+
+	commitMessages := []string{"Merge pull request", "skipped commit 1", "skipped commit 2"}
+
+	vals := &Values{}
+	for _, commitMessage := range commitMessages {
+		skippedCommits = appendToValues(vals, commitMessage, changelogMessage, skippedCommits)
+	}
+
+	assert.Equal(t, len(skippedCommits), 2, "skipped commits length")
+	assert.Equal(t, vals, &Values{}, "vals")
 }


### PR DESCRIPTION
...instead of instantiating a new one each time appendToValues is invoked!

