### PR TITLE
fix(map.json): add registry-proxy component

### DIFF
--- a/map.json
+++ b/map.json
@@ -10,6 +10,7 @@
   "postgres": "database",
   "redis": "redis",
   "registry": "registry",
+  "registry-proxy": "registry-proxy",
   "registry-token-refresher": "registry-token-refresher",
   "router": "router",
   "slugbuilder": "slugbuilder",


### PR DESCRIPTION
`deisrel workflow/requirements.lock map.json` wasn't reporting on registry-proxy.